### PR TITLE
Add option to output EXECVE.ARGV_STR

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -13,3 +13,19 @@ generations = 10
 # Grant read permissions on the log files to these users, using
 # POSIX ACLs
 read-users = [ "splunk" ]
+
+[transform]
+
+# "array" (the default) causes EXECVE a0, a1, a2 … arguments to be
+# output as a list of strings, "ARGV". This is the default, it allows
+# analysts to reliably reproduce what was executed.
+#
+# "string" causes arguments to be concatenated into a single string,
+# separated by space characters, "ARGV_STR". This form allows for
+# easier grepping, but it is impossible to tell if space characters in
+# the resulting string are a separator or were part of an individual
+# argument in the original command line.
+
+execve-argv = [ "array" ]
+
+#  execve-argv = [ "array", "string" ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::collections::HashSet;
 
 use serde::{Serialize,Deserialize};
 
@@ -11,8 +12,19 @@ pub struct Logfile {
     pub generations: Option<u64>,
 }
 
+#[derive(PartialEq,Eq,Debug,Serialize,Deserialize,Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum ArrayOrString { Array, String }
+
+impl Default for ArrayOrString {
+    fn default() -> Self { ArrayOrString::Array }
+}
+
 #[derive(Default,Debug,Serialize,Deserialize)]
-pub struct Transform {}
+pub struct Transform {
+    #[serde(rename="execve-argv")] #[serde(default)]
+    pub execve_argv: HashSet<ArrayOrString>
+}
 
 #[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Enrich {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,8 @@ fn run_app() -> Result<(), Box<dyn Error>> {
         }}));
 
     let mut coalesce = Coalesce::default();
+    coalesce.execve_argv_list = config.transform.execve_argv.contains(&ArrayOrString::Array);
+    coalesce.execve_argv_string = config.transform.execve_argv.contains(&ArrayOrString::String);
     coalesce.populate_proc_table()
         .map_err(|e| format!("populate proc table: {}", e))?;
     let mut line: Vec<u8> = Vec::new();


### PR DESCRIPTION
The default behavior to only produce EXECVE.ARGV is unchanged.

Close: #4