### PR TITLE
Wrap known SELinux with gen_require to fix re-definition errors.

### DIFF
--- a/contrib/selinux/laurel.te
+++ b/contrib/selinux/laurel.te
@@ -11,8 +11,10 @@ permissive laurel_t;
 
 init_daemon_domain(laurel_t, laurel_exec_t)
 
-type auditd_t;
-type passwd_file_t;
+gen_require(`
+  type auditd_t;
+  type passwd_file_t;
+')
 
 # auditd -> laurel
 allow auditd_t laurel_exec_t:file { getattr open read execute entrypoint };


### PR DESCRIPTION
It is the proper way to use the gen_require block for external types. More
importantly, some SELinux versions will complain during module loading
about re-definition of types.