### PR TITLE
Send informational logging to syslog

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::collections::HashSet;
+use std::env;
 
 use serde::{Serialize,Deserialize};
 
@@ -78,6 +79,19 @@ impl Default for Config {
             enrich: Enrich::default(),
             filter: Filter::default(),
         }
+    }
+}
+
+impl std::fmt::Display for Config {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(fmt, "(user={} directory={} file={} users={} size={} generations={})", 
+                self.user.clone().unwrap_or("n/a".to_string()), 
+                self.directory.clone().unwrap_or(env::current_dir().unwrap()).display(), 
+                self.auditlog.file.to_string_lossy(), 
+                self.auditlog.users.clone().unwrap_or(vec!["n/a".to_string()]).join(","), 
+                self.auditlog.size.unwrap_or(0), 
+                self.auditlog.generations.unwrap_or(0)
+        )
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::collections::HashSet;
-use std::env;
 
 use serde::{Serialize,Deserialize};
 
@@ -85,11 +84,11 @@ impl Default for Config {
 impl std::fmt::Display for Config {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         write!(fmt, "(user={} directory={} file={} users={} size={} generations={})", 
-                self.user.clone().unwrap_or("n/a".to_string()), 
-                self.directory.clone().unwrap_or(env::current_dir().unwrap()).display(), 
-                self.auditlog.file.to_string_lossy(), 
-                self.auditlog.users.clone().unwrap_or(vec!["n/a".to_string()]).join(","), 
-                self.auditlog.size.unwrap_or(0), 
+                self.user.clone().unwrap_or("n/a".to_string()),
+                self.directory.clone().unwrap_or_else(||PathBuf::from(".")).display(),
+                self.auditlog.file.to_string_lossy(),
+                self.auditlog.users.clone().unwrap_or(vec!["n/a".to_string()]).join(","),
+                self.auditlog.size.unwrap_or(0),
                 self.auditlog.generations.unwrap_or(0)
         )
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,9 +33,7 @@ impl Default for Transform {
 #[derive(Debug,Serialize,Deserialize)]
 pub struct Enrich {
     #[serde(rename="execve-env")] #[serde(default)]
-    pub execve_env: HashSet<String>,
-    #[serde(rename="silent")] #[serde(default)]
-    pub silent: bool
+    pub execve_env: HashSet<String>
 }
 
 impl Default for Enrich {
@@ -43,8 +41,7 @@ impl Default for Enrich {
         let mut execve_env = HashSet::new();
         execve_env.insert("LD_PRELOAD".into());
         execve_env.insert("LD_LIBRARY_PATH".into());
-        let silent = false;
-        Enrich { execve_env, silent }
+        Enrich { execve_env }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,9 @@ impl Default for Transform {
 #[derive(Debug,Serialize,Deserialize)]
 pub struct Enrich {
     #[serde(rename="execve-env")] #[serde(default)]
-    pub execve_env: HashSet<String>
+    pub execve_env: HashSet<String>,
+    #[serde(rename="silent")] #[serde(default)]
+    pub silent: bool
 }
 
 impl Default for Enrich {
@@ -41,7 +43,8 @@ impl Default for Enrich {
         let mut execve_env = HashSet::new();
         execve_env.insert("LD_PRELOAD".into());
         execve_env.insert("LD_LIBRARY_PATH".into());
-        Enrich { execve_env }
+        let silent = false;
+        Enrich { execve_env, silent }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use caps::{Capability, CapSet};
 use caps::securebits::set_keepcaps;
 
 use serde::Serialize;
-use serde_json::{self};
+use serde_json;
 
 use laurel::coalesce::Coalesce;
 use laurel::rotate::FileRotate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,6 @@ fn run_app() -> Result<(), Box<dyn Error>> {
     let mut opts = Options::new();
     opts.optopt("c", "config", "Configuration file", "FILE");
     opts.optflag("d", "dry-run", "Only parse configuration and exit");
-    opts.optflag("s", "silent", "Suppress laurel's status messages in audit.log");
     opts.optflag("h", "help", "Print short help text and exit");
 
     let matches = opts.parse(&args[1..])?;
@@ -121,13 +120,6 @@ fn run_app() -> Result<(), Box<dyn Error>> {
         },
         None => Config::default(),
     };
-    
-    let is_silent;
-
-    match matches.opt_present("s") {
-        true => is_silent = true,
-        false => is_silent = config.enrich.silent
-    }
 
     let runas_user = match config.user {
         Some(ref username) => User::from_name(username)?
@@ -196,31 +188,25 @@ fn run_app() -> Result<(), Box<dyn Error>> {
     };
 
     if !Uid::effective().is_root() {
-        if let false = is_silent {
-            logger.log(&json!({"warning": "Not dropping privileges -- \
-                                        not running as root"}))
-        }
+        logger.log(&json!({"warning": "Not dropping privileges -- not running as root"}));
     } else if runas_user.uid.is_root() {
-        if let false = is_silent {
-            logger.log(&json!({"warning": "Not dropping privileges -- no user configured"}))
-        }
+        logger.log(&json!({"warning": "Not dropping privileges -- no user configured"}));
     } else if let Err(e) = drop_privileges(&runas_user) {
         logger.log(&json!({"fatal": e.to_string()}));
         return Err(e);
     }
 
     // Initial setup is done at this point.
-    if let false = is_silent {
-        logger.log(&json!({
-            "notice": {
-                "program": &args[0],
-                "action": "start",
-                "euid": Uid::effective().as_raw(),
-                "version": env!("CARGO_PKG_VERSION"),
-                "config": &config
-            }}))
-    }
-    
+
+    logger.log(&json!({
+        "notice": {
+            "program": &args[0],
+            "action": "start",
+            "euid": Uid::effective().as_raw(),
+            "version": env!("CARGO_PKG_VERSION"),
+            "config": &config
+        }}));
+
     let mut coalesce = Coalesce::default();
     coalesce.execve_argv_list = config.transform.execve_argv.contains(&ArrayOrString::Array);
     coalesce.execve_argv_string = config.transform.execve_argv.contains(&ArrayOrString::String);
@@ -256,11 +242,8 @@ fn run_app() -> Result<(), Box<dyn Error>> {
         };
     }
 
-    if let false = is_silent {
-        logger.log(&json!({"notice": { "program": &args[0], "action":
-                                             "stop", "stats": &stats }}))
-    }
-    
+    logger.log(&json!({"notice": { "program": &args[0], "action": "stop", "stats": &stats }}));
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,15 +196,13 @@ fn run_app() -> Result<(), Box<dyn Error>> {
     };
 
     if !Uid::effective().is_root() {
-        match is_silent {
-            false => logger.log(&json!({"warning": "Not dropping privileges -- \
-                                        not running as root"})),
-            true => {}
+        if let false = is_silent {
+            logger.log(&json!({"warning": "Not dropping privileges -- \
+                                        not running as root"}))
         }
     } else if runas_user.uid.is_root() {
-        match is_silent {
-            false => logger.log(&json!({"warning": "Not dropping privileges -- no user configured"})),
-            true => {}
+        if let false = is_silent {
+            logger.log(&json!({"warning": "Not dropping privileges -- no user configured"}))
         }
     } else if let Err(e) = drop_privileges(&runas_user) {
         logger.log(&json!({"fatal": e.to_string()}));
@@ -212,16 +210,15 @@ fn run_app() -> Result<(), Box<dyn Error>> {
     }
 
     // Initial setup is done at this point.
-    match is_silent {
-         false => logger.log(&json!({
+    if let false = is_silent {
+        logger.log(&json!({
             "notice": {
                 "program": &args[0],
                 "action": "start",
                 "euid": Uid::effective().as_raw(),
                 "version": env!("CARGO_PKG_VERSION"),
                 "config": &config
-            }})),
-        true => {}
+            }}))
     }
     
     let mut coalesce = Coalesce::default();
@@ -259,9 +256,9 @@ fn run_app() -> Result<(), Box<dyn Error>> {
         };
     }
 
-    match is_silent {
-        false => logger.log(&json!({"notice": { "program": &args[0], "action": "stop", "stats": &stats }})),
-        true => {}
+    if let false = is_silent {
+        logger.log(&json!({"notice": { "program": &args[0], "action":
+                                             "stop", "stats": &stats }}))
     }
     
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use caps::{Capability, CapSet};
 use caps::securebits::set_keepcaps;
 
 use serde::Serialize;
-use serde_json::{self,json};
+use serde_json::{self};
 
 use laurel::coalesce::Coalesce;
 use laurel::rotate::FileRotate;
@@ -26,7 +26,7 @@ use laurel::config::{ArrayOrString,Config};
 mod syslog {
     use std::ffi::CString;
     use std::mem::forget;
-    use libc::{openlog,syslog,LOG_DAEMON,LOG_WARNING,LOG_CRIT,LOG_PERROR};
+    use libc::{openlog, syslog, LOG_CRIT, LOG_DAEMON, LOG_INFO, LOG_PERROR, LOG_WARNING};
 
     pub fn init(progname: &String) {
         let ident = CString::new(progname.as_str()).unwrap();
@@ -35,21 +35,29 @@ mod syslog {
         // not be dropped.
         forget(ident);
     }
-
+    pub fn log_info(message: &str) {
+        let fs = CString::new("%s").unwrap();
+        let s = CString::new(message).unwrap();
+        unsafe { syslog(LOG_INFO | LOG_DAEMON, fs.as_ptr(), s.as_ptr()) };
+    }
     pub fn log_warn(message: &str) {
         let fs = CString::new("%s").unwrap();
         let s = CString::new(message).unwrap();
-        unsafe { syslog(LOG_WARNING|LOG_DAEMON, fs.as_ptr(), s.as_ptr()) };
+        unsafe { syslog(LOG_WARNING | LOG_DAEMON, fs.as_ptr(), s.as_ptr()) };
     }
-
+    pub fn log_err(message: &str) {
+        let fs = CString::new("%s").unwrap();
+        let s = CString::new(message).unwrap();
+        unsafe { syslog(LOG_PERROR | LOG_DAEMON, fs.as_ptr(), s.as_ptr()) };
+    }
     pub fn log_crit(message: &str) {
         let fs = CString::new("%s").unwrap();
         let s = CString::new(message).unwrap();
-        unsafe { syslog(LOG_CRIT|LOG_DAEMON, fs.as_ptr(), s.as_ptr()) };
+        unsafe { syslog(LOG_CRIT | LOG_DAEMON, fs.as_ptr(), s.as_ptr()) };
     }
 }
 
-use syslog::{log_warn,log_crit};
+use syslog::{log_crit, log_err, log_info, log_warn};
 
 #[derive(Default,Serialize)]
 struct Stats { lines: u64, events: u64, errors: u64 }
@@ -188,24 +196,25 @@ fn run_app() -> Result<(), Box<dyn Error>> {
     };
 
     if !Uid::effective().is_root() {
-        logger.log(&json!({"warning": "Not dropping privileges -- not running as root"}));
+        log_warn("Not dropping privileges -- not running as root");
     } else if runas_user.uid.is_root() {
-        logger.log(&json!({"warning": "Not dropping privileges -- no user configured"}));
+        log_warn("Not dropping privileges -- no user configured");
     } else if let Err(e) = drop_privileges(&runas_user) {
-        logger.log(&json!({"fatal": e.to_string()}));
+        // Logged to syslog by caller
         return Err(e);
     }
 
     // Initial setup is done at this point.
 
-    logger.log(&json!({
-        "notice": {
-            "program": &args[0],
-            "action": "start",
-            "euid": Uid::effective().as_raw(),
-            "version": env!("CARGO_PKG_VERSION"),
-            "config": &config
-        }}));
+    log_info(
+        format!(
+            "Started {} running version {}",
+            &args[0],
+            env!("CARGO_PKG_VERSION")
+        )
+        .as_str(),
+    );
+    log_info(format!("Running with EUID {} using config {}", Uid::effective().as_raw(), &config).as_str());
 
     let mut coalesce = Coalesce::default();
     coalesce.execve_argv_list = config.transform.execve_argv.contains(&ArrayOrString::Array);
@@ -236,14 +245,20 @@ fn run_app() -> Result<(), Box<dyn Error>> {
             Err(e) => {
                 stats.errors += 1;
                 let line = String::from_utf8_lossy(&line);
-                logger.log(&json!({"error": { "message": e.to_string(), "input": &line }}));
+                log_err(format!("Error {} processing msg: {}", e.to_string(), &line).as_str());
                 continue
             }
         };
     }
 
-    logger.log(&json!({"notice": { "program": &args[0], "action": "stop", "stats": &stats }}));
-
+    log_info(
+        format!(
+            "Stopped {} processed {} lines {} events with {} errors in total",
+            &args[0], &stats.lines, &stats.events, &stats.errors
+        )
+        .as_str(),
+    );
+    
     Ok(())
 }
 


### PR DESCRIPTION
Dear Hilko, 

this patch adds a CLI switch `-s` as well as a field in the .toml-config file named `silent`, which enables the user to suppress `laurel`'s behaviour to write status messages (like `{"notice":...}` or `{"warning":...}`) in the resulting audit.log. I think that this is a helpful addition for users who want to retain an `audit.log` which is very close to the original one without employing any filtering. 

If you have any suggestions for changing the implementation, please let me know.

Thanks already in advance for considering this PR. 

Best regards,
Jan   
