### PR TITLE
Add SYSCALL.key-based process label feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(),Box<dyn std::error::Error>> {
 
     // Artificial record
     constants.push(("PARENT_INFO".into(), "0xffffff00".into()));
+    constants.push(("LABELS".into(), "0xffffff01".into()));
 
     let fields: Vec<(String, String)> =
         BufReader::new(fs::File::open(fields_file)?)

--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -45,3 +45,12 @@ user-db = false
 
 # List of environment variables to log for every EXECVE event
 execve-env = [ "LD_PRELOAD", "LD_LIBRARY_PATH" ]
+
+[label-process]
+
+# Processes pereforming operations that result in audit records with
+# these attached keys will get all subsequent actions labelled by
+# LAUREL:
+label-keys = [ "software_mgmt" ]
+# Subprocesses inherit these keys from their parent.
+propagate-labels = [ "software_mgmt" ]

--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -48,9 +48,9 @@ execve-env = [ "LD_PRELOAD", "LD_LIBRARY_PATH" ]
 
 [label-process]
 
-# Processes pereforming operations that result in audit records with
-# these attached keys will get all subsequent actions labelled by
-# LAUREL:
+# When processes perform operations that result in audit records with
+# these attached keys, LAUREL will attach the key as a label to the
+# process:
 label-keys = [ "software_mgmt" ]
 # Subprocesses inherit these keys from their parent.
 propagate-labels = [ "software_mgmt" ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,14 @@ impl Default for Enrich {
 }
 
 #[derive(Default,Debug,Serialize,Deserialize)]
+pub struct LabelProcess {
+    #[serde(rename="label-keys")]
+    pub label_keys: HashSet<String>,
+    #[serde(rename="propagate-labels")]
+    pub propagate_labels: HashSet<String>,
+}
+
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Filter {}
 
 #[derive(Debug,Serialize,Deserialize)]
@@ -67,6 +75,8 @@ pub struct Config {
     pub translate: Translate,
     #[serde(default)]
     pub enrich: Enrich,
+    #[serde(default,rename="label-process")]
+    pub label_process: LabelProcess,
     #[serde(default)]
     pub filter: Filter,
 }
@@ -86,6 +96,7 @@ impl Default for Config {
             transform: Transform::default(),
             translate: Translate::default(),
             enrich: Enrich::default(),
+            label_process: LabelProcess::default(),
             filter: Filter::default(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,12 @@ fn run_app() -> Result<(), Box<dyn Error>> {
         .map_err(|e| format!("populate proc table: {}", e))?;
     coalesce.translate_universal = config.translate.universal;
     coalesce.translate_userdb = config.translate.userdb;
+    coalesce.proc_label_keys = config.label_process.label_keys.iter()
+        .map( |s| s.as_bytes().to_vec() )
+        .collect();
+    coalesce.proc_propagate_labels = config.label_process.propagate_labels.iter()
+        .map( |s| s.as_bytes().to_vec() )
+        .collect();
 
     let mut line: Vec<u8> = Vec::new();
     let mut stats = Stats::default();


### PR DESCRIPTION
This feature allows for adding labels to processes or process subtrees based on the "key" attribute transmitted with the SYSCALL message.

A typical usecase would be add labels based on specific filesystem events (exec of apt, rpm, yum, ssm-agent, etc.) in order to add context for actions taken by admin or package maintainer scripts that can be queried easily.