### PR TITLE
Periodical status report to Syslog.

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -2,6 +2,10 @@
 directory = "/var/log/laurel"
 # Drop privileges from root to this user
 user = "_laurel"
+# The periodical time window in seconds for status information to be printed to Syslog.
+# Status report includes the running version, config and parsing stats.
+# Default is 0 --> no status reports.
+statusreport-period = 0
 
 [auditlog]
 # Base file name for the JSONL-based log file. Set to "-" to log to stdout. In this case 

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,8 @@ pub struct Filter {}
 pub struct Config {
     pub user: Option<String>,
     pub directory: Option<PathBuf>,
+    #[serde(rename="statusreport-period")] #[serde(default)]
+    pub statusreport_period: Option<u64>,
     pub auditlog: Logfile,
     pub debuglog: Option<Logfile>,
     #[serde(default)]
@@ -76,6 +78,7 @@ impl Default for Config {
         Config {
             user: None,
             directory: Some(".".into()),
+            statusreport_period: None,
             auditlog: Logfile {
                 file: "audit.log".into(),
                 users: None,
@@ -93,9 +96,10 @@ impl Default for Config {
 
 impl std::fmt::Display for Config {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        write!(fmt, "(user={} directory={} file={} users={} size={} generations={})",
+        write!(fmt, "(user={} directory={} statusreport-period={} file={} users={} size={} generations={})",
                self.user.clone().unwrap_or("n/a".to_string()),
                self.directory.clone().unwrap_or_else(||PathBuf::from(".")).display(),
+               self.statusreport_period.unwrap_or(0),
                self.auditlog.file.to_string_lossy(),
                self.auditlog.users.clone().unwrap_or(vec!["n/a".to_string()]).join(","),
                self.auditlog.size.unwrap_or(0),
@@ -114,6 +118,7 @@ mod test {
         let c: Config = toml::de::from_str(r#"
 user = "somebody"
 directory = "/path/to/somewhere"
+statusreport-period = 86400
 [auditlog]
 file = "somefile"
 read-users = ["splunk"]
@@ -121,6 +126,7 @@ read-users = ["splunk"]
         println!("{:#?}", &c);
         assert_eq!(c.user, Some("somebody".to_string()));
         assert_eq!(c.directory, Some(Path::new("/path/to/somewhere").to_path_buf()));
+        assert_eq!(c.statusreport_period, Some(86400));
         assert_eq!(c.auditlog, Logfile{
             file: Path::new("somefile").to_path_buf(),
             users: Some(vec!["splunk".to_string()]),


### PR DESCRIPTION
The report contains
* running version and EUID
* loaded config
* and parsing stats
This feature enables simple checking of Laurel status of Syslog.

I am undecided about the parsing stats. I left the overall stats in every report message. 
Maybe it makes more sense to log only the stats between reporting windows and in the end the overall stats.
Thereby one can search on every X-time period for new ones.

Alternatively, leave the stats from the periodical reports altogether. In case parsing error occur, the prompted to Syslog immediately anyway.