### PR TITLE
Feature/parser fix

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -705,6 +705,8 @@ mod test {
 
         let (_n, _t, _id, _rv) = parse(Vec::from(include_bytes!("testdata/line-netfilter.txt").as_ref()))?;
 
+        let (_n, _t, _id, _rv) = parse(Vec::from(include_bytes!("testdata/line-anom-abend.txt").as_ref()))?;
+
         Ok(())
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -373,6 +373,10 @@ fn parse_unspec_value<'a>(input: &'a[u8], ty: MessageType, name: &[u8]) -> IResu
             |s| -> Result<_,()> { Ok(PValue::Str(s, Quote::Single)) }
         ),
         map_res(
+            delimited(tag("\""), take_while(|c| c != b'"'), tag("\"")),
+            |s| -> Result<_,()> { Ok(PValue::Str(s, Quote::Double)) }
+        ),
+        map_res(
             delimited(tag("{"), take_while(|c| c != b'}'), tag("}")),
             |s| -> Result<_,()> { Ok(PValue::Str(s, Quote::Braces)) }
         ),

--- a/src/testdata/line-anom-abend.txt
+++ b/src/testdata/line-anom-abend.txt
@@ -1,0 +1,1 @@
+type=ANOM_ABEND msg=audit(1633653915.934:123): auid=4294967295 uid=1000 gid=1000 ses=4294967295 pid=1000 comm="ftptls" reason="memory violation" sig=6AUID="unset" UID="some-user" GID="some-group"


### PR DESCRIPTION
It turned out that even double-quoted strings may contain "characters with [special meaning](https://github.com/linux-audit/audit-documentation/wiki/SPEC-Writing-Good-Events) to the parser".