### PR TITLE
Do not rotate if filesize is 0

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -113,8 +113,8 @@ impl std::fmt::Display for Config {
                self.statusreport_period.unwrap_or(0),
                self.auditlog.file.to_string_lossy(),
                self.auditlog.users.clone().unwrap_or(vec!["n/a".to_string()]).join(","),
-               self.auditlog.size.unwrap_or(0),
-               self.auditlog.generations.unwrap_or(0)
+               self.auditlog.size.unwrap_or(10*1024*1024),
+               self.auditlog.generations.unwrap_or(5)
         )
     }
 }

--- a/src/rotate.rs
+++ b/src/rotate.rs
@@ -85,7 +85,7 @@ impl Write for FileRotate {
         let mut f = self.file.as_ref().unwrap();
         let sz = f.write(buf)?;
         self.offset += sz as u64;
-        if self.offset > self.filesize {
+        if self.offset > self.filesize && self.filesize != 0 {
             f.sync_all()?;
             self.rotate()?;
         }


### PR DESCRIPTION
We are using Laurel in a way that file rotate is annoying. Instead of having to set u64::MAX in the configuration, I propose that setting 0 should disable file rotation.

Moreover the config is printing invalid values at startup, if size and generation are not set, the defaults one from rotate are used, not 0.

Let me know what you think about it, i'm not a Rust expert. :sweat_smile: 