### PR TITLE
Add support for rsyslog lumberjack mechanism

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -51,6 +51,12 @@ universal = false
 # UID, GID values
 user-db = false
 
+# Optional section to enable lumberjack formatting for rsyslog
+# [out_format]
+
+# lumberjack = true
+# prefix = "@notceecookie:"
+
 [enrich]
 
 # List of environment variables to log for every EXECVE event

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,11 @@ pub struct Filter {
     pub filter_keys: HashSet<String>,
 }
 
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct OutFormat {
+    pub lumberjack: bool,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub user: Option<String>,
@@ -102,6 +107,8 @@ pub struct Config {
     pub label_process: LabelProcess,
     #[serde(default)]
     pub filter: Filter,
+    #[serde(default)]
+    pub out_format: OutFormat,
 }
 
 impl Default for Config {
@@ -122,6 +129,7 @@ impl Default for Config {
             enrich: Enrich::default(),
             label_process: LabelProcess::default(),
             filter: Filter::default(),
+            out_format: OutFormat::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,7 @@ pub struct Filter {
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct OutFormat {
     pub lumberjack: bool,
+    pub prefix: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod coalesce;
 pub mod config;
 pub mod constants;
 pub mod label_matcher;
+pub mod lumberjack;
 pub mod parser;
 pub mod proc;
 pub mod quoted_string;

--- a/src/lumberjack.rs
+++ b/src/lumberjack.rs
@@ -1,0 +1,197 @@
+use std::io;
+
+const PREFIX: &str = "@cee:";
+const DEFAULT_CAPACITY: usize = 10;
+
+pub struct LumberjackWriter {
+    buf_size: usize,
+    cur_line: usize,
+    buffer: Vec<Vec<u8>>,
+    wrapped: Box<dyn io::Write>,
+}
+
+enum AppendResult {
+    Done(usize),
+    Continue(usize),
+}
+
+fn init_buffer<'a>(buffer: &'a mut Vec<Vec<u8>>, buf_size: usize) {
+    for _ in 0..buf_size {
+        buffer.push(vec![]);
+    }
+}
+
+impl LumberjackWriter {
+    pub fn new(wrapped: Box<dyn io::Write>) -> Self {
+        Self::with_capacity(wrapped, DEFAULT_CAPACITY)
+    }
+
+    pub fn with_capacity(wrapped: Box<dyn io::Write>, buf_size: usize) -> Self {
+        let mut buffer = Vec::with_capacity(buf_size);
+        init_buffer(&mut buffer, buf_size);
+        assert_eq!(buffer.len(), buf_size);
+        Self {
+            buf_size,
+            wrapped,
+            buffer,
+            cur_line: 0,
+        }
+    }
+
+    fn add_to_buffer(&mut self, content: &[u8], cur_pos: usize) -> AppendResult {
+        let mut counter: usize = 0;
+
+        for c in content {
+            counter += 1;
+            self.buffer[self.cur_line].push(*c);
+
+            if *c == 0x0a {
+                self.cur_line += 1;
+
+                if self.cur_line < self.buf_size {
+                    return self.add_to_buffer(&content[counter..], counter + cur_pos);
+                } else {
+                    self.cur_line = 0;
+                    return AppendResult::Continue(counter + cur_pos);
+                }
+            }
+        }
+
+        AppendResult::Done(counter + cur_pos)
+    }
+
+    fn write_whole_buffer(&mut self) -> Result<(), io::Error> {
+        assert_eq!(self.buffer.len(), self.buf_size);
+        for i in 0..self.buf_size {
+            if self.buffer[i].is_empty() {
+                return Ok(());
+            }
+            self.wrapped.write(PREFIX.as_bytes())?;
+            self.wrapped.write(&self.buffer[i])?;
+            self.buffer[i] = vec![];
+        }
+        Ok(())
+    }
+}
+
+impl io::Write for LumberjackWriter {
+    fn flush(&mut self) -> Result<(), io::Error> {
+        self.write_whole_buffer()?;
+        self.wrapped.flush()
+    }
+
+    // write must pass the given content through the inner buffer first. Once this
+    // is full, a write of the wrapped writer is called with the contained data and
+    // the index of the content up to which the data has been read is returned. The
+    // write must continue in this way until the whole content has been scanned.
+    fn write(&mut self, content: &[u8]) -> Result<usize, std::io::Error> {
+        let mut written: usize = 0;
+
+        loop {
+            match self.add_to_buffer(content[written..].into(), 0) {
+                AppendResult::Continue(partial) => {
+                    self.write_whole_buffer()?;
+                    written += partial;
+                }
+                AppendResult::Done(total) => {
+                    return Ok(written + total);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::LumberjackWriter;
+    use std::cell::RefCell;
+    use std::io::{self, Read, Write};
+
+    #[derive(Debug)]
+    struct Buf(RefCell<Vec<u8>>);
+
+    impl Buf {
+        const fn new() -> Self {
+            Self(RefCell::new(Vec::new()))
+        }
+
+        fn to_owned(&self) -> String {
+            String::from(std::str::from_utf8(self.0.borrow().as_ref()).unwrap())
+        }
+    }
+
+    impl Read for &Buf {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+            let size = std::cmp::min(self.0.borrow().len(), buf.len());
+
+            for i in 0..size {
+                buf[i] = self.0.borrow()[i];
+            }
+
+            Ok(size)
+        }
+    }
+
+    impl Write for &Buf {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+            for b in buf {
+                self.0.borrow_mut().push(*b);
+            }
+
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> Result<(), io::Error> {
+            Ok(())
+        }
+    }
+
+    impl PartialEq<Vec<u8>> for &Buf {
+        fn eq(&self, other: &Vec<u8>) -> bool {
+            *self.0.borrow() == *other
+        }
+    }
+
+    unsafe impl Sync for Buf {}
+
+    #[test]
+    fn test_full_write() {
+        static BUF: Buf = Buf::new();
+
+        let mut lw = LumberjackWriter::with_capacity(Box::new(&BUF), 3);
+
+        let three = "{\"number\":1}\n{\"number\":2}\n{\"number\":3,\"notUnicode\":\"é\"}\n";
+        let exp_three =
+            "@cee:{\"number\":1}\n@cee:{\"number\":2}\n@cee:{\"number\":3,\"notUnicode\":\"é\"}\n";
+        let written = lw.write(three.as_bytes()).expect("unexpected ìo error");
+        assert_eq!(written, three.len());
+        assert_eq!(BUF.to_owned(), exp_three);
+
+        let two = "{\"number\":4}\n{\"number\":5}\n";
+        let written2 = lw.write(two.as_bytes()).expect("unexpected io error");
+        assert_eq!(written2, two.len());
+        assert_eq!(BUF.to_owned(), exp_three);
+
+        let one = "{\"number\":6}\n";
+        let exp_two_and_one = "@cee:{\"number\":4}\n@cee:{\"number\":5}\n@cee:{\"number\":6}\n";
+        let mut exp_six = exp_three.to_owned();
+        exp_six.push_str(exp_two_and_one);
+        let written3 = lw.write(one.as_bytes()).expect("unexpected io error");
+        assert_eq!(written3, one.len());
+        assert_eq!(BUF.to_owned(), exp_six);
+    }
+
+    #[test]
+    fn test_flush() {
+        static BUF: Buf = Buf::new();
+
+        let mut lw = LumberjackWriter::with_capacity(Box::new(&BUF), 3);
+
+        let two = "{\"number\":4}\n{\"number\":5}\n";
+        let exp_two = "@cee:{\"number\":4}\n@cee:{\"number\":5}\n";
+        let written2 = lw.write(two.as_bytes()).expect("unexpected io error");
+        lw.flush().expect("failed to flush");
+
+        assert_eq!(written2, two.len());
+        assert_eq!(BUF.to_owned(), exp_two);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ impl Logger {
                 output: Box::new(BufWriter::new(Box::new(io::stdout()))),
             }),
             p if p.as_os_str() == "-" && lumberjack => Ok(Logger {
-                output: Box::new(LumberjackWriter::new(Box::new(io::stdout()))),
+                output: Box::new(LumberjackWriter::new(Box::new(io::stdout()), None)),
             }),
             p if p.has_root() && p.parent() != None => Err(format!(
                 "invalid file directory={} file={}",
@@ -162,7 +162,7 @@ impl Logger {
                 }
                 if lumberjack {
                     Ok(Logger {
-                        output: Box::new(LumberjackWriter::new(Box::new(rot))),
+                        output: Box::new(LumberjackWriter::new(Box::new(rot), None)),
                     })
                 } else {
                     Ok(Logger {


### PR DESCRIPTION
Hi! Thanks for this software!

I am opening this PR to add a functionality I am interested in to better integrate the `auditd` machinery together with `rsyslog`. The juice of the feature regards the ability for rsyslog to be able to [recognize the beginning of a json structure][r] in a log line. This is achieved prepending a _cookie_ (`@cee:`) before the log line. In the case of `laurel` as an `auditd` plugin, this means that such cookie should be present at the beginning of each line. I thought first of implementing a custom serde serializer, but this is impossible as a serializer has no notion of level and cannot tell when an object is at the beginning of a line. The approach I took here is to use a custom Writer (an implementation of `std::io::Write`) that mimics a `BufWriter`, buffering in an internal buffer _per line_ instead of using the byte size as measure.
To enable this mechanism, I added a new section in the configuration file, with a single boolean option

```toml
[out_format]

lumberjack = true
```

that defaults to `false` (the current behavior).

You will notice that there are A LOT of lines in the PR diff. This is because I use (neo)vim and `rust-analyzer` in the language server machinery. It is not feasible for me to work without it and this machinery autoformats the code at each save. I run `cargo fmt` on the whole code base and saved it as first commit. The remaining commits in the PR implement what I described above. I beg you to accept this not as a disrespectful act, but rather as a way for you and me to foster public collaboration :innocent: 

[r]: https://www.rsyslog.com/doc/master/configuration/modules/mmjsonparse.html#purpose