### PR TITLE
Add accessors to `Event`.

### DIFF
--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -62,6 +62,12 @@ impl Event {
             filter: false,
         }
     }
+    pub fn id(&self) -> EventID {
+        self.id
+    }
+    pub fn records(&self) -> indexmap::map::Iter<'_, MessageType, EventValues> {
+        self.body.iter()
+    }
 }
 
 impl Serialize for Event {


### PR DESCRIPTION
`Event` is not terribly complex; once constructed you can serialize it & that's about it-- which of course is fine for the `laurel` binary. However,  Laurel provides a library as well as a binary crate. If an app wishes to use _just_ the library crate (as mine does), it can't do much without access to `Event` state.
This commit allows callers to retrieve the Event ID as well as an iterator over the Event's records (both operations are non-mutating).