### PR TITLE
Explicitly set permitted, inheritable capabilities

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,8 +98,12 @@ fn drop_privileges(runas_user: &User) -> Result<(), Box<dyn Error>> {
     let mut capabilities = HashSet::new();
     capabilities.insert(Capability::CAP_SYS_PTRACE);
     capabilities.insert(Capability::CAP_DAC_READ_SEARCH);
+    caps::set(None, CapSet::Permitted, &capabilities)
+        .map_err(|e| format!("set effective capabilities: {}", e))?;
     caps::set(None, CapSet::Effective, &capabilities)
-        .map_err(|e| format!("set capabilities: {}", e))?;
+        .map_err(|e| format!("set effective capabilities: {}", e))?;
+    caps::set(None, CapSet::Inheritable, &HashSet::new())
+        .map_err(|e| format!("set inherited capabilities: {}", e))?;
 
     set_keepcaps(false)?;
     Ok(())


### PR DESCRIPTION
Permitted capabilities can be regained by laurel itself. Those are limited to what is actually needed. If an exploitable arbitrary code execution vulnerability is discovered in Laurel, this limits what can be done within the process.

Inhereitable capabilities are transferred across execve, those are eliminated altogether. If a vulnerability is discovered that may cause laurel to launch arbitrary programs, such a program will not inherit any special capabilities, only the _laurel user.