### PR TITLE
Avoid clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::coalesce::Settings;
 use crate::label_matcher::LabelMatcher;
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Logfile {
     #[serde(default)]
     pub file: PathBuf,
@@ -18,7 +18,7 @@ pub struct Logfile {
     pub line_prefix: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Debug {
     pub log: Option<Logfile>,
     #[serde(rename = "parse-error-log")]

--- a/src/const.rs.in
+++ b/src/const.rs.in
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 
-#[derive(PartialEq,Clone,Copy)]
+#[derive(PartialEq,Eq,Clone,Copy)]
 pub enum FieldType {
     Encoded,
     Numeric,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -186,14 +186,12 @@ fn parse_body(
                 many1(terminated(parse_identifier, space0)),
                 tuple((tag("}"), space0, tag("for"), space0)),
             )),
-            |(_, k, _, v, _)| -> Result<_, ()> {
-                Ok((Key::Name(NVec::from(&*k)), PValue::List(v)))
-            },
+            |(_, k, _, v, _)| -> Result<_, ()> { Ok((Key::Name(NVec::from(k)), PValue::List(v))) },
         ),
         map_res(
             tuple((tag("netlabel"), tag(":"), space0)),
             |(s, _, _): (&[u8], _, _)| -> Result<_, ()> {
-                Ok((Key::Name(NVec::from(&*s)), PValue::Empty))
+                Ok((Key::Name(NVec::from(s)), PValue::Empty))
             },
         ),
     )))(input)?;
@@ -498,11 +496,11 @@ fn parse_key(input: &[u8]) -> IResult<&[u8], Key> {
             if let Ok(c) = Common::try_from(s) {
                 Ok(Key::Common(c))
             } else if s.ends_with(b"uid") {
-                Ok(Key::NameUID(NVec::from(&*s)))
+                Ok(Key::NameUID(NVec::from(s)))
             } else if s.ends_with(b"gid") {
-                Ok(Key::NameGID(NVec::from(&*s)))
+                Ok(Key::NameGID(NVec::from(s)))
             } else {
-                Ok(Key::Name(NVec::from(&*s)))
+                Ok(Key::Name(NVec::from(s)))
             }
         },
     )(input)

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -19,24 +19,24 @@ pub struct SocketAddrLL {
 }
 */
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrLocal {
     pub path: Vec<u8>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrAX25 {
     pub call: [u8; 7],
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrATMPVC {
     pub itf: i16,
     pub vpi: i16,
     pub vci: i32,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrIPX {
     pub port: u16,
     pub network: u32,
@@ -44,24 +44,24 @@ pub struct SocketAddrIPX {
     pub typ: u8,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrX25 {
     pub address: [u8; 16],
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrVM {
     pub port: u32,
     pub cid: u32,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SocketAddrNL {
     pub pid: u32,
     pub groups: u32,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SocketAddr {
     Local(SocketAddrLocal),
     Inet(SocketAddrV4),

--- a/src/types.rs
+++ b/src/types.rs
@@ -187,7 +187,7 @@ impl Display for Common {
 pub(crate) type NVec = tinyvec::TinyVec<[u8; 14]>;
 
 /// Representation of the key part of key/value pairs in [`Record`]
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum Key {
     /// regular ASCII-only name as returned by parser
     Name(NVec),
@@ -280,7 +280,7 @@ impl PartialEq<[u8]> for Key {
 }
 
 /// Quotes in [`Value`] strings
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum Quote {
     None,
     Single,


### PR DESCRIPTION
- you are deriving `PartialEq` and can implement `Eq`
- deref on an immutable reference