### PR TITLE
Analyse exec events for script execution

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -80,6 +80,9 @@ execve-env = [ "LD_PRELOAD", "LD_LIBRARY_PATH" ]
 # Add container context to SYSCALL-based events
 container = true
 
+# Add script context to SYSCALL execve events
+script = true
+
 [label-process]
 
 # Audit records that contain certain keys can be reused as a label
@@ -97,6 +100,10 @@ label-keys = [ "software_mgmt" ]
 label-exe.'^/opt/.*/bin/java$' = 'java'
 label-exe.'^/usr/lib/jvm/.*/bin/java$' = 'java'
 label-exe.'^/snap/amazon-ssm-agent/\d+/' = 'amazon-ssm-agent'
+
+# Labels can be attached to processes that have been identified as
+# scripts.
+label-script."maint" = "^/root/maint-.*[.]sh$"
 
 # Process Labels can be propagated to spawned child processes. This is
 # useful for marking an entire subtree of children that have been

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,8 @@ pub struct Enrich {
     pub container: bool,
     #[serde(default = "true_value")]
     pub pid: bool,
+    #[serde(default = "true_value")]
+    pub script: bool,
 }
 
 impl Default for Enrich {
@@ -92,6 +94,7 @@ impl Default for Enrich {
             execve_env: execve_env_default(),
             container: true,
             pid: true,
+            script: true,
         }
     }
 }
@@ -102,6 +105,8 @@ pub struct LabelProcess {
     pub label_keys: HashSet<String>,
     #[serde(default, rename = "label-exe")]
     pub label_exe: Option<LabelMatcher>,
+    #[serde(default, rename = "label-script")]
+    pub label_script: Option<LabelMatcher>,
     #[serde(default, rename = "propagate-labels")]
     pub propagate_labels: HashSet<String>,
 }
@@ -196,6 +201,7 @@ impl Config {
                 .collect(),
             enrich_container: self.enrich.container,
             enrich_pid: self.enrich.pid,
+            enrich_script: self.enrich.script,
             proc_label_keys: self
                 .label_process
                 .label_keys
@@ -211,6 +217,7 @@ impl Config {
             translate_universal: self.translate.universal,
             translate_userdb: self.translate.userdb,
             label_exe: self.label_process.label_exe.as_ref(),
+            label_script: self.label_process.label_script.as_ref(),
             filter_keys: self
                 .filter
                 .filter_keys


### PR DESCRIPTION
For execve events, assume that differences between the file referenced by SYSCALL.exe and the first PATH entry indicate that a script is being invoked through the "#!" mechanism.

If the PATH entry contains relative path, ".", "..", and double slashes are normalized.

This information is used to add SYSCALL.SCRIPT and to add process labels.

Caveats:

1. Inspecting SYSCALL.exe is racy.

2. SYSCALL.exe is looked at through the /proc/<pid>/root "lens" to try to treat mount namespaces used by container runtimes containers properly. Unfortunately, this does not seem to work for Podman containers yet.