### PR TITLE
Build different SELinux policy variants for differnt distros

### DIFF
--- a/.github/workflows/selinux.yml
+++ b/.github/workflows/selinux.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: |
-          make -C contrib/selinux
+          make -C contrib/selinux AUDITD_VERSIONS=2
       - name: Archive policy
         uses: actions/upload-artifact@v3
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: |
-          make -C contrib/selinux
+          make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
         uses: actions/upload-artifact@v3
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: |
-          make -C contrib/selinux
+          make -C contrib/selinux AUDITD_VERSIONS=2
       - name: Archive policy
         uses: actions/upload-artifact@v3
         with:

--- a/contrib/selinux/Makefile
+++ b/contrib/selinux/Makefile
@@ -1,4 +1,10 @@
+# auditd 2.x and 3.x are different in how they launch plugins.
+# Override AUDIT_AUDIT_VERSIONS to select only one variant.
+AUDITD_VERSIONS = 2 3
+
 include /usr/share/selinux/devel/Makefile
+
+M4PARAM += $(foreach v,$(AUDITD_VERSIONS),-D audit$(v))
 
 .PHONY: install
 install: laurel.pp laurel.if

--- a/contrib/selinux/laurel.te
+++ b/contrib/selinux/laurel.te
@@ -11,16 +11,27 @@ permissive laurel_t;
 
 init_daemon_domain(laurel_t, laurel_exec_t)
 
-gen_require(`
-  type auditd_t;
-  type passwd_file_t;
+gen_require(`type passwd_file_t;')
+
+# auditd (auditd 3+) -> laurel
+ifdef(`audit3',`
+	gen_require(`type auditd_t;')
+
+	allow auditd_t laurel_exec_t:file { getattr open read execute entrypoint };
+	type_transition auditd_t laurel_exec_t:process laurel_t;
+	allow auditd_t auditd_t:capability kill;
+	allow auditd_t laurel_t:process { transition signal };
 ')
 
-# auditd -> laurel
-allow auditd_t laurel_exec_t:file { getattr open read execute entrypoint };
-type_transition auditd_t laurel_exec_t:process laurel_t;
-allow auditd_t auditd_t:capability kill;
-allow auditd_t laurel_t:process { transition signal };
+# audispd (auditd 2.x) -> laurel
+ifdef(`audit2',`
+	gen_require(`type audisp_t;')
+
+	allow audisp_t laurel_exec_t:file { getattr open read execute entrypoint };
+	type_transition audisp_t laurel_exec_t:process laurel_t;
+	allow audisp_t audisp_t:capability kill;
+	allow audisp_t laurel_t:process { transition signal };
+')
 
 # Set / retain capabilities
 allow laurel_t self:process { getcap setcap };


### PR DESCRIPTION
While auditd 3.x spawns plug-ins directly, auditd 2.x uses audispd as an intermediary, therefore different transitions ought to be defined.

Building an "universal" policy is still possible as of EL9 (Rocky), but we don't know whether this will last.