### PR TITLE
Added null key filter #137

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -130,3 +130,7 @@ propagate-labels = [ "software_mgmt", "amazon-ssm-agent" ]
 # filtering. This alows the possibility to filter based on parent processes.
 
 # filter-labels = ["software_mgmt"]
+
+# Filter events without specified key
+
+filter-null-keys = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,8 @@ pub struct Filter {
     pub filter_keys: HashSet<String>,
     #[serde(default, rename = "filter-labels")]
     pub filter_labels: HashSet<String>,
+    #[serde(default, rename = "filter-null-keys")]
+    pub filter_null_keys: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -244,6 +246,7 @@ impl Config {
                 .iter()
                 .map(|s| s.as_bytes().to_vec())
                 .collect(),
+            filter_null_keys: self.filter.filter_null_keys,
         }
     }
 }

--- a/src/testdata/record-syscall-nullkey.txt
+++ b/src/testdata/record-syscall-nullkey.txt
@@ -1,0 +1,10 @@
+type=PROCTITLE msg=audit(1678282381.452:102337): proctitle="(systemd)"
+type=SYSCALL msg=audit(1678282381.452:102337): arch=c000003e syscall=1 success=yes exit=5 a0=9 a1=7ffd4ac563d1 a2=5 a3=0 items=0 ppid=1 pid=3489504 auid=34005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=15589 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
+type=EOE msg=audit(1678282381.452:102337): 
+type=PROCTITLE msg=audit(1678282320.958:102262): proctitle=536f6d6552616e646f6d50726f63657373
+type=SYSCALL msg=audit(1678282320.958:102262): arch=c000003e syscall=1 success=yes exit=5 a0=3 a1=7ffd9f4453e0 a2=5 a3=0 items=0 ppid=8750 pid=3483623 auid=34025 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=15584 comm="sshd" exe="/bin/sshd" subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)
+type=EOE msg=audit(1678282320.958:102262): 
+type=PROCTITLE msg=audit(1678283440.683:225): proctitle=536f6d6552616e646f6d50726f63657373
+type=PATH msg=audit(1678283440.683:225): item=0 name="/proc/2414/root/usr/bin/su" inode=156161 dev=fd:00 mode=0104755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:su_exec_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0
+type=SYSCALL msg=audit(1678283440.683:225): arch=c000003e syscall=4 success=yes exit=0 a0=7edd0caa2e7e0 a1=7345b64adba0 a2=7ff9874adba0 a3=feefeffefefefeff items=1 ppid=816 pid=818 auid=4292467295 uid=502 gid=502 euid=502 suid=502 fsuid=502 egid=502 sgid=502 fsgid=502 tty=(none) ses=4296967295 comm="cat" exe="/usr/bin/cat" subj=system_u:system_r:system_t:s0 key=(null)
+type=EOE msg=audit(1678283440.683:225):


### PR DESCRIPTION
* Additional test case inside of filter_key
* Else case after key check

**Note:** If the "null" key string is contained in the filter_keys array, this will filter out all events not containing a key. One could argue that the auditd rule-set should specify all events which should be logged and therefore set keys for the events leading to no unwanted "null" keys (make explicit what is implicit)

As to my understanding other tools like Sysmon are also only logging what is specified in the config.

Looking forward to feedback and opinions