### PR TITLE
Add a basic container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
     tags:
       - "v*"
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   prep:
     runs-on: ubuntu-latest
@@ -60,6 +64,12 @@ jobs:
           asset_path: laurel.tar.gz
           asset_name: laurel-${{ needs.prep.outputs.git_version }}-x86_64-musl.tar.gz
           asset_content_type: application/tar
+      # Use tar to keep permissions
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: laurel
+          path: laurel.tar.gz
 
   build-glibc:
     needs: prep
@@ -104,3 +114,83 @@ jobs:
           asset_path: laurel.tar.gz
           asset_name: laurel-${{ needs.prep.outputs.git_version }}-x86_64-glibc.tar.gz
           asset_content_type: application/tar
+
+  build-container-image:
+    needs: build-musl
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v2.1.1
+        with:
+          name: laurel
+          path: .
+
+      # use tar to keep permissions
+      - name: Unpack Build Artifact
+        run: tar -xzf laurel.tar.gz
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.13.1'
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/static-debian11
+
+COPY laurel /usr/bin/laurel
+COPY etc/laurel/config.toml /etc/laurel/config.toml
+ENTRYPOINT ["/usr/bin/laurel"]
+CMD ["--config", "/etc/laurel/config.toml"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We developed _LAUREL_ because we were not content with feature sets and performa
 
 ## Container Image
 
-From v0.5.2 on laurel is able to listen on an socket for forwarded auditd messages and can be executed in a container this way. A basic container image is published in this repository to `ghcr.io/threathunters.io/laurel` with tags latest and the respective version tag.
+From v0.5.2 on laurel is able to listen on an socket for forwarded auditd messages and can be executed in a container this way. A basic container image is published in this repository to `ghcr.io/threathunters-io/laurel` with tags latest and the respective version tag.
 
 The provided container image build includes default labels via docker buildx from the pipeline. These labels are not included in the provided Dockerfile but are considered good practice. If you use a custom build with another tooling, consider adding the default labels to the Dockerfile.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The [_LAUREL_ installation instructions](INSTALL.md) contain instructions on how
 
 We developed _LAUREL_ because we were not content with feature sets and performance characteristics of existing projects and products. Please refer to the [Performance](performance.md) document for details.
 
+## Container Image
+
+From v0.5.2 on laurel is able to listen on an socket for forwarded auditd messages and can be executed in a container this way. A basic container image is published in this repository to `ghcr.io/threathunters.io/laurel` with tags latest and the respective version tag.
+
+The provided container image build includes default labels via docker buildx from the pipeline. These labels are not included in the provided Dockerfile but are considered good practice. If you use a custom build with another tooling, consider adding the default labels to the Dockerfile.
+
+The container image currently contains the default configuration, which does not include the socket connection and other container specifics. Please replace this configuration with the configuration of your choice, it is meant as a placeholder.
+
 ## License
 
 GNU General Public License, version 3


### PR DESCRIPTION
This patch introduces a basic container image as Dockerfile and build workflow via GitHub Actions. The container image is automatically built on tags and pushed to ghcr.io.