### PR TITLE
Restart laurel on SIGHUP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "signal-hook",
  "simple_logger",
  "syslog",
  "tinyvec",
@@ -550,6 +551,25 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simple_logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ caps = "0.5"
 libc = "0.2"
 exacl = ">= 0.6"
 regex = "1"
+signal-hook = "0.3"
 tinyvec = { version = "1", features = ["alloc"] }
 
 log = "0.4"

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -1054,6 +1054,11 @@ impl<'a> Coalesce<'a> {
         Ok(())
     }
 
+    /// Flush all in-flight event data, including partial events
+    pub fn flush(&mut self) {
+        self.expire_inflight(u64::MAX);
+    }
+
     pub fn dump_state(&self, mut w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
         serde_json::to_writer(
             &mut w,
@@ -1092,7 +1097,7 @@ impl<'a> Coalesce<'a> {
 
 impl Drop for Coalesce<'_> {
     fn drop(&mut self) {
-        self.expire_inflight(u64::MAX)
+        self.flush();
     }
 }
 


### PR DESCRIPTION
When we catch SIGHUP, all remaining input in the buffer is fed to coalesce, coalesce is flushed. Laurel is restarted with identical configuration parameters and capabilities.

Implements part of #133