### PR TITLE
Move procfs-specific code into optional module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ bindgen = ">= 0.60"
 bencher = "0"
 gperftools = "0"
 
+[features]
+procfs = []
+default = ["procfs"]
+
 [[bench]]
 name = "coalesce_execve"
 harness = false

--- a/src/bin/laurel/main.rs
+++ b/src/bin/laurel/main.rs
@@ -65,8 +65,11 @@ fn drop_privileges(runas_user: &User) -> Result<(), Box<dyn Error>> {
     setresuid(uid, uid, uid).map_err(|e| format!("setresuid({}): {}", gid, e))?;
 
     let mut capabilities = HashSet::new();
-    capabilities.insert(Capability::CAP_SYS_PTRACE);
-    capabilities.insert(Capability::CAP_DAC_READ_SEARCH);
+    #[cfg(feature = "procfs")]
+    {
+        capabilities.insert(Capability::CAP_SYS_PTRACE);
+        capabilities.insert(Capability::CAP_DAC_READ_SEARCH);
+    }
     caps::set(None, CapSet::Permitted, &capabilities)
         .map_err(|e| format!("set permitted capabilities: {}", e))?;
     caps::set(None, CapSet::Effective, &capabilities)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod label_matcher;
 pub mod logger;
 pub mod parser;
 pub mod proc;
+#[cfg(feature = "procfs")]
+pub mod procfs;
 pub mod quoted_string;
 pub mod rotate;
 pub mod sockaddr;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,18 +1,8 @@
 use std::boxed::Box;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
-use std::fs::{read_dir, read_link, File};
-use std::io::{BufRead, BufReader, Read};
 use std::iter::Iterator;
-use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
-use std::str::FromStr;
 use std::vec::Vec;
-
-use lazy_static::lazy_static;
-use nix::sys::time::TimeSpec;
-use nix::time::{clock_gettime, ClockId};
-use nix::unistd::{sysconf, SysconfVar};
 
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
@@ -20,64 +10,20 @@ use serde::{Serialize, Serializer};
 use crate::label_matcher::LabelMatcher;
 use crate::types::{EventID, Number, Record, Value};
 
-lazy_static! {
-    /// kernel clock ticks per second
-    static ref CLK_TCK: u64
-        = sysconf(SysconfVar::CLK_TCK).unwrap().unwrap() as u64;
-}
-
-/// Read contents of file, return buffer.
-fn slurp_file(path: impl AsRef<Path>) -> Result<Vec<u8>, Box<dyn Error>> {
-    let f = File::open(path)?;
-    let mut r = BufReader::with_capacity(1 << 16, f);
-    r.fill_buf()?;
-    let mut buf = Vec::with_capacity(8192);
-    r.read_to_end(&mut buf)?;
-    Ok(buf)
-}
+#[cfg(feature = "procfs")]
+use crate::procfs;
 
 #[derive(Clone, Debug, Default)]
 pub struct ContainerInfo {
     pub id: Vec<u8>,
 }
 
-fn extract_sha256(buf: &[u8]) -> Option<&[u8]> {
-    if buf.len() < 64 {
-        None
-    } else if buf[buf.len() - 64..].iter().all(u8::is_ascii_hexdigit) {
-        Some(&buf[buf.len() - 64..])
-    } else if buf[..64].iter().all(u8::is_ascii_hexdigit) {
-        Some(&buf[..64])
-    } else {
-        None
-    }
-}
-
-fn parse_proc_pid_cgroup(buf: &[u8]) -> Result<ContainerInfo, Box<dyn Error>> {
-    for line in buf.split(|c| *c == b'\n') {
-        let dir = line.split(|&c| c == b':').nth(2);
-        if dir.is_none() {
-            continue;
-        }
-        for fragment in dir.unwrap().split(|&c| c == b'/') {
-            let fragment = if fragment.ends_with(&b".scope"[..]) {
-                &fragment[..fragment.len() - 6]
-            } else {
-                fragment
-            };
-            match extract_sha256(fragment) {
-                None => continue,
-                Some(id) => return Ok(ContainerInfo { id: Vec::from(id) }),
-            }
-        }
-    }
-    Err("no sha256 sum found".into())
-}
-
+#[cfg(feature = "procfs")]
 impl ContainerInfo {
     fn parse_proc(pid: u32) -> Result<ContainerInfo, Box<dyn Error>> {
-        let buf = slurp_file(format!("/proc/{}/cgroup", pid))?;
-        parse_proc_pid_cgroup(&buf)
+        procfs::parse_proc_pid_cgroup(pid).map(|id| ContainerInfo {
+            id: id.unwrap_or_default(),
+        })
     }
 }
 
@@ -93,6 +39,7 @@ pub struct Process {
     pub event_id: Option<EventID>,
     pub comm: Option<Vec<u8>>,
     pub exe: Option<Vec<u8>>,
+    #[cfg(feature = "procfs")]
     pub container_info: Option<ContainerInfo>,
 }
 
@@ -129,72 +76,29 @@ impl Serialize for Process {
     }
 }
 
+#[cfg(feature = "procfs")]
+impl From<procfs::ProcPidInfo> for Process {
+    fn from(p: procfs::ProcPidInfo) -> Self {
+        Self {
+            launch_time: p.starttime,
+            ppid: p.ppid,
+            labels: HashSet::new(),
+            event_id: None,
+            comm: p.comm,
+            exe: p.exe,
+            container_info: p.container_id.map(|id| ContainerInfo { id }),
+        }
+    }
+}
+
 impl Process {
     /// Generate a shadow process table entry from /proc/$PID for a given PID
-    #[allow(dead_code)]
+    #[cfg(feature = "procfs")]
     pub fn parse_proc(pid: u32) -> Result<Process, Box<dyn Error>> {
-        let buf = slurp_file(format!("/proc/{}/stat", pid))
-            .map_err(|e| format!("read /proc/{}/stat: {}", pid, e))?;
-        // comm may contain whitespace and ")", skip over it.
-        let comm_end = buf
-            .iter()
-            .enumerate()
-            .rfind(|(_, c)| **c == b')')
-            .ok_or("end of 'cmd' field not found")?
-            .0;
-        let stat = &buf[comm_end + 2..]
-            .split(|c| *c == b' ')
-            .collect::<Vec<_>>();
-
-        let event_id = None;
-        let comm = slurp_file(format!("/proc/{}/comm", pid))
-            .map(|mut s| {
-                s.truncate(s.len() - 1);
-                s
-            })
-            .ok();
-
-        let exe = read_link(format!("/proc/{}/exe", pid))
-            .map(|p| Vec::from(p.as_os_str().as_bytes()))
-            .ok();
-
-        // see proc(5), /proc/[pid]/stat (4)
-        let ppid = u32::from_str(String::from_utf8_lossy(stat[1]).as_ref())?;
-        // see proc(5), /proc/[pid]/stat (22)
-        let starttime = u64::from_str(String::from_utf8_lossy(stat[19]).as_ref())?;
-
-        // Use the boottime-based clock to calculate process start
-        // time, convert to Unix-epoch-based-time.
-        let proc_boottime = TimeSpec::from(libc::timespec {
-            tv_sec: (starttime / *CLK_TCK) as _,
-            tv_nsec: ((starttime % *CLK_TCK) * (1_000_000_000 / *CLK_TCK)) as _,
-        });
-        let proc_age = clock_gettime(ClockId::CLOCK_BOOTTIME)
-            .map_err(|e| format!("clock_gettime: {}", e))?
-            - proc_boottime;
-        let launch_time = {
-            let lt = clock_gettime(ClockId::CLOCK_REALTIME)
-                .map_err(|e| format!("clock_gettime: {}", e))?
-                - proc_age;
-            (lt.tv_sec() * 1000 + lt.tv_nsec() / 1_000_000) as u64
-        };
-
-        let container_info = ContainerInfo::parse_proc(pid).ok();
-
-        let labels = HashSet::new();
-        Ok(Process {
-            launch_time,
-            ppid,
-            labels,
-            event_id,
-            comm,
-            exe,
-            container_info,
-        })
+        procfs::parse_proc_pid(pid).map(|p| p.into())
     }
 
     /// Use a processed EXECVE event to generate a shadow process table entry
-    #[allow(dead_code)]
     pub fn parse_execve(id: &EventID, rsyscall: &Record) -> Result<(u32, Process), Box<dyn Error>> {
         let mut p = Process {
             launch_time: id.timestamp,
@@ -230,14 +134,6 @@ pub struct ProcTable {
     pub processes: BTreeMap<u32, Process>,
 }
 
-fn get_pids() -> Result<Vec<u32>, Box<dyn Error>> {
-    Ok(read_dir("/proc")
-        .map_err(|e| format!("read_dir: /proc: {}", e))?
-        .flatten()
-        .filter_map(|e| u32::from_str(e.file_name().to_string_lossy().as_ref()).ok())
-        .collect::<Vec<u32>>())
-}
-
 impl ProcTable {
     /// Constructs process table from /proc entries
     ///
@@ -250,7 +146,9 @@ impl ProcTable {
         let mut pt = ProcTable {
             processes: BTreeMap::new(),
         };
-        for pid in get_pids()? {
+
+        #[cfg(feature = "procfs")]
+        for pid in procfs::get_pids()? {
             // /proc/<pid> access is racy. Ignore errors here.
             if let Ok(mut proc) = Process::parse_proc(pid) {
                 if let (Some(label_exe), Some(exe)) = (label_exe, &proc.exe) {
@@ -299,6 +197,7 @@ impl ProcTable {
         let labels = HashSet::new();
         let launch_time = id.timestamp;
         let event_id = Some(id);
+        #[cfg(feature = "procfs")]
         let container_info = ContainerInfo::parse_proc(pid)
             .ok()
             .or_else(|| self.get_process(ppid)?.container_info);
@@ -312,6 +211,7 @@ impl ProcTable {
                 event_id,
                 comm,
                 exe,
+                #[cfg(feature = "procfs")]
                 container_info,
             },
         );
@@ -322,16 +222,15 @@ impl ProcTable {
     /// information from /proc.
     pub fn get_process(&mut self, pid: u32) -> Option<Process> {
         if let Some(p) = self.processes.get(&pid) {
-            Some(p.clone())
-        } else {
-            match Process::parse_proc(pid) {
-                Ok(p) => {
-                    self.processes.insert(pid, p.clone());
-                    Some(p)
-                }
-                Err(_) => None,
-            }
+            return Some(p.clone());
         }
+        #[cfg(feature = "procfs")]
+        if let Ok(p) = Process::parse_proc(pid) {
+            self.processes.insert(pid, p.clone());
+            return Some(p);
+        }
+
+        None
     }
 
     /// Removes a process from the table
@@ -346,26 +245,30 @@ impl ProcTable {
     /// It should be possible to run this every few seconds without
     /// incurring load.
     pub fn expire(&mut self) {
-        // initialize prune list with all known processes
-        let mut prune: HashSet<u32> = self.processes.keys().cloned().collect();
-        let live_processes = match get_pids() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-        // remove from prune list all live processes and their
-        // parents, excluding pid1
-        for seed_pid in live_processes {
-            let mut pid = seed_pid;
-            while let Some(proc) = self.processes.get(&pid) {
-                if pid <= 1 || !prune.remove(&pid) {
-                    break;
+        // Expire is a no-op if parsing /proc is not enabled!
+        #[cfg(feature = "procfs")]
+        {
+            // initialize prune list with all known processes
+            let mut prune: HashSet<u32> = self.processes.keys().cloned().collect();
+            let live_processes = match procfs::get_pids() {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            // remove from prune list all live processes and their
+            // parents, excluding pid1
+            for seed_pid in live_processes {
+                let mut pid = seed_pid;
+                while let Some(proc) = self.processes.get(&pid) {
+                    if pid <= 1 || !prune.remove(&pid) {
+                        break;
+                    }
+                    pid = proc.ppid;
                 }
-                pid = proc.ppid;
             }
+            prune.iter().for_each(|pid| {
+                self.processes.remove(pid);
+            });
         }
-        prune.iter().for_each(|pid| {
-            self.processes.remove(pid);
-        });
     }
 
     pub fn add_label(&mut self, pid: u32, label: &[u8]) {
@@ -381,27 +284,6 @@ impl ProcTable {
     }
 }
 
-type Environment = Vec<(Vec<u8>, Vec<u8>)>;
-
-/// Returns environment for a given process
-pub fn get_environ<F>(pid: u32, pred: F) -> Result<Environment, Box<dyn Error>>
-where
-    F: Fn(&[u8]) -> bool,
-{
-    let buf = slurp_file(format!("/proc/{}/environ", pid))?;
-    let mut res = Vec::new();
-
-    for e in buf.split(|c| *c == 0) {
-        let mut kv = e.splitn(2, |c| *c == b'=');
-        let k = kv.next().unwrap_or_default();
-        if pred(k) {
-            let v = kv.next().unwrap_or_default();
-            res.push((k.to_owned(), v.to_owned()));
-        }
-    }
-    Ok(res)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -410,19 +292,6 @@ mod tests {
         let pt = ProcTable::from_proc(None, &HashSet::new())?;
         for p in pt.processes {
             println!("{:?}", &p);
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn parse_cgroup() -> Result<(), Box<dyn Error>> {
-        let testdata = &br#"0::/system.slice/docker-47335b04ebb4aefdc353dda62ddd38e5e1e00fc1372f0c8d0138417f0ccb9e6c.scope
-0::/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-974a75c8cf45648fcc6e718ba92ee1f2034463674f0d5b0c50f5cab041a4cbd6.scope/container
-"#[..];
-        {
-            parse_proc_pid_cgroup(&testdata).map_err(|e| {
-                Box::<dyn Error>::from(format!("{}: {}", String::from_utf8_lossy(&testdata), e))
-            })?;
         }
         Ok(())
     }

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -1,0 +1,195 @@
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fs::{read_dir, read_link, File, Metadata};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::str::FromStr;
+
+use lazy_static::lazy_static;
+use nix::sys::time::TimeSpec;
+use nix::time::{clock_gettime, ClockId};
+use nix::unistd::{sysconf, SysconfVar};
+
+lazy_static! {
+    /// kernel clock ticks per second
+    static ref CLK_TCK: u64
+        = sysconf(SysconfVar::CLK_TCK).unwrap().unwrap() as u64;
+}
+
+/// Read contents of file, return buffer.
+fn slurp_file(path: impl AsRef<Path>) -> Result<Vec<u8>, Box<dyn Error>> {
+    let f = File::open(path)?;
+    let mut r = BufReader::with_capacity(1 << 16, f);
+    r.fill_buf()?;
+    let mut buf = Vec::with_capacity(8192);
+    r.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+type Environment = Vec<(Vec<u8>, Vec<u8>)>;
+
+/// Returns set of environment variables that match pred for a given process
+pub fn get_environ<F>(pid: u32, pred: F) -> Result<Environment, Box<dyn Error>>
+where
+    F: Fn(&[u8]) -> bool,
+{
+    let buf = slurp_file(format!("/proc/{}/environ", pid))?;
+    let mut res = Vec::new();
+
+    for e in buf.split(|c| *c == 0) {
+        let mut kv = e.splitn(2, |c| *c == b'=');
+        let k = kv.next().unwrap_or_default();
+        if pred(k) {
+            let v = kv.next().unwrap_or_default();
+            res.push((k.to_owned(), v.to_owned()));
+        }
+    }
+    Ok(res)
+}
+
+/// Returns all currently valid process IDs
+pub fn get_pids() -> Result<Vec<u32>, Box<dyn Error>> {
+    Ok(read_dir("/proc")
+        .map_err(|e| format!("read_dir: /proc: {}", e))?
+        .flatten()
+        .filter_map(|e| u32::from_str(e.file_name().to_string_lossy().as_ref()).ok())
+        .collect::<Vec<u32>>())
+}
+
+/// Returns file metadata for a path from a process' perspective
+pub fn pid_path_metadata(pid: u32, path: &[u8]) -> Result<Metadata, std::io::Error> {
+    if path.is_empty() || path[0] != b'/' {
+        return Err(std::io::ErrorKind::NotFound.into());
+    }
+    let mut proc_path = Vec::with_capacity(20 + path.len());
+    // unwrap safety: write will not produce an IO error
+    write!(proc_path, "/proc/{pid}/root").unwrap();
+    proc_path.extend(path);
+    std::fs::metadata(OsStr::from_bytes(&proc_path))
+}
+
+pub(crate) struct ProcPidInfo {
+    /// /proc/<pid>/stat field 4
+    pub ppid: u32,
+    /// /proc/<pid>/stat field 22, converted to milliseconds since epoch
+    pub starttime: u64,
+    /// /proc/pid/comm
+    pub comm: Option<Vec<u8>>,
+    /// /proc/pid/exe
+    pub exe: Option<Vec<u8>>,
+    /// sha256 from /proc/pid/cgroup
+    pub container_id: Option<Vec<u8>>,
+}
+
+/// Parses information from /proc entry corresponding to process pid
+pub(crate) fn parse_proc_pid(pid: u32) -> Result<ProcPidInfo, Box<dyn Error>> {
+    let buf = slurp_file(format!("/proc/{}/stat", pid))
+        .map_err(|e| format!("read /proc/{}/stat: {}", pid, e))?;
+    // comm may contain whitespace and ")", skip over it.
+    let comm_end = buf
+        .iter()
+        .enumerate()
+        .rfind(|(_, c)| **c == b')')
+        .ok_or("end of 'cmd' field not found")?
+        .0;
+    let stat = &buf[comm_end + 2..]
+        .split(|c| *c == b' ')
+        .collect::<Vec<_>>();
+
+    let comm = slurp_file(format!("/proc/{}/comm", pid))
+        .map(|mut s| {
+            s.truncate(s.len() - 1);
+            s
+        })
+        .ok();
+
+    let exe = read_link(format!("/proc/{}/exe", pid))
+        .map(|p| Vec::from(p.as_os_str().as_bytes()))
+        .ok();
+
+    // see proc(5), /proc/[pid]/stat (4)
+    let ppid = u32::from_str(String::from_utf8_lossy(stat[1]).as_ref())?;
+    // see proc(5), /proc/[pid]/stat (22)
+    let starttime = u64::from_str(String::from_utf8_lossy(stat[19]).as_ref())?;
+
+    // Use the boottime-based clock to calculate process start
+    // time, convert to Unix-epoch-based-time.
+    let proc_boottime = TimeSpec::from(libc::timespec {
+        tv_sec: (starttime / *CLK_TCK) as _,
+        tv_nsec: ((starttime % *CLK_TCK) * (1_000_000_000 / *CLK_TCK)) as _,
+    });
+    let proc_age = clock_gettime(ClockId::CLOCK_BOOTTIME)
+        .map_err(|e| format!("clock_gettime: {}", e))?
+        - proc_boottime;
+    let starttime = {
+        let lt = clock_gettime(ClockId::CLOCK_REALTIME)
+            .map_err(|e| format!("clock_gettime: {}", e))?
+            - proc_age;
+        (lt.tv_sec() * 1000 + lt.tv_nsec() / 1_000_000) as u64
+    };
+
+    let container_id = parse_proc_pid_cgroup(pid)?;
+
+    Ok(ProcPidInfo {
+        ppid,
+        starttime,
+        comm,
+        exe,
+        container_id,
+    })
+}
+
+fn extract_sha256(buf: &[u8]) -> Option<&[u8]> {
+    if buf.len() < 64 {
+        None
+    } else if buf[buf.len() - 64..].iter().all(u8::is_ascii_hexdigit) {
+        Some(&buf[buf.len() - 64..])
+    } else if buf[..64].iter().all(u8::is_ascii_hexdigit) {
+        Some(&buf[..64])
+    } else {
+        None
+    }
+}
+
+/// Parses "container id" (some SHA256 sum) from /proc/pid/cgroup
+pub(crate) fn parse_proc_pid_cgroup(pid: u32) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+    parse_cgroup_buf(&slurp_file(format!("/proc/{}/cgroup", pid))?)
+}
+
+fn parse_cgroup_buf(buf: &[u8]) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+    for line in buf.split(|c| *c == b'\n') {
+        let dir = line.split(|&c| c == b':').nth(2);
+        if dir.is_none() {
+            continue;
+        }
+        for fragment in dir.unwrap().split(|&c| c == b'/') {
+            let fragment = if fragment.ends_with(&b".scope"[..]) {
+                &fragment[..fragment.len() - 6]
+            } else {
+                fragment
+            };
+            match extract_sha256(fragment) {
+                None => continue,
+                Some(id) => return Ok(Some(Vec::from(id))),
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn parse_cgroup() -> Result<(), Box<dyn std::error::Error>> {
+        let testdata = br#"0::/system.slice/docker-47335b04ebb4aefdc353dda62ddd38e5e1e00fc1372f0c8d0138417f0ccb9e6c.scope
+0::/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-974a75c8cf45648fcc6e718ba92ee1f2034463674f0d5b0c50f5cab041a4cbd6.scope/container
+"#;
+        {
+            super::parse_cgroup_buf(testdata).map_err(|e| -> Box<dyn std::error::Error> {
+                format!("{}: {}", String::from_utf8_lossy(testdata), e).into()
+            })?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Making procfs support optional lets us build a "pure" filtering version of Laurel for debugging purposes or for running in non-auditd-plugin setups.