### PR TITLE
Add LoongArch support

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -59,6 +59,8 @@ const ARCHS: &[(&str, u32)] = &[
     ("hexagon", 0x000000a4),
     ("i386", 0x40000003),
     ("ia64", 0xc0000032),
+    ("loongarch32", 0x40000102),
+    ("loongarch64", 0xc0000102),
     ("m32r", 0x00000058),
     ("m68k", 0x00000004),
     ("microblaze", 0x000000bd),


### PR DESCRIPTION
Add LoongArch support, please review.

The output data are as follows,
- The results of print-audit-archs
```("aarch64", 0xc00000b7),\n("alpha", 0xc0009026),\n("arcompact", 0x4000005d),\n("arcompactbe", 0x0000005d),\n("arcv2", 0x400000c3),\n("arcv2be", 0x000000c3),\n("arm", 0x40000028),\n("armeb", 0x00000028),\n("c6x", 0x4000008c),\n("c6xbe", 0x0000008c),\n("cris", 0x4000004c),\n("csky", 0x400000fc),\n("frv", 0x00005441),\n("h8300", 0x0000002e),\n("hexagon", 0x000000a4),\n("i386", 0x40000003),\n("ia64", 0xc0000032),\n("loongarch32", 0x40000102),\n("loongarch64", 0xc0000102),\n("m32r", 0x00000058),\n("m68k", 0x00000004),\n("microblaze", 0x000000bd),\n("mips", 0x00000008),\n("mips64", 0x80000008),\n("mips64n32", 0xa0000008),\n("mipsel", 0x40000008),\n("mipsel64", 0xc0000008),\n("mipsel64n32", 0xe0000008),\n("nds32", 0x400000a7),\n ......```
- The method of query
```
echo 'printf("(\"%s\", 0x%08x),\\n", lc("AUDIT_ARCH_LOONGARCH32") + 11, AUDIT_ARCH_LOONGARCH32);'
echo 'printf("(\"%s\", 0x%08x),\\n", lc("AUDIT_ARCH_LOONGARCH64") + 11, AUDIT_ARCH_LOONGARCH64);'
#define AUDIT_ARCH_LOONGARCH32  (EM_LOONGARCH|__AUDIT_ARCH_LE)
#define AUDIT_ARCH_LOONGARCH64  (EM_LOONGARCH|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)
```
thanks,
Dandan Zhang