### PR TITLE
Implement filtering on individual raw audit records

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -148,6 +148,12 @@ propagate-labels = [ "software_mgmt", "amazon-ssm-agent" ]
 
 filter-null-keys = false
 
+# Filter events that were constructed from input lines matching these
+# regular expressions
+# filter-raw-lines = [
+#     "^type=PATH msg=\\S*? item=\\S*? name=\"/var/run/nscd[.]sock\" "
+# ]
+
 # What to do with filtered events? "drop" or "log" to the filterlog
 # defined above.
 filter-action = "drop"

--- a/man/laurel.8.md
+++ b/man/laurel.8.md
@@ -169,6 +169,9 @@ using them for internal processing such as process tracking.
 - `filter-null-keys`: Filter events without specified key. Default: false
 - `filter-labels`: A list of strings that are matched against process
   labels. Default: empty
+- `filter-raw-lines`: A list of regular expression that are matched
+  against individual input lines as written by `auditd(8)`. Events
+  that contain such lines are then filtered. Default: empty
 - `filter-action`: What to do with filtered events? `drop` or `log` to the
   filterlog defined above.
 

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -49,6 +49,7 @@ pub struct Settings {
     pub filter_keys: HashSet<Vec<u8>>,
     pub filter_labels: HashSet<Vec<u8>>,
     pub filter_null_keys: bool,
+    pub filter_raw_lines: regex::bytes::RegexSet,
 }
 
 impl Default for Settings {
@@ -74,6 +75,7 @@ impl Default for Settings {
             filter_keys: HashSet::new(),
             filter_labels: HashSet::new(),
             filter_null_keys: false,
+            filter_raw_lines: regex::bytes::RegexSet::empty(),
         }
     }
 }
@@ -983,6 +985,8 @@ impl<'a> Coalesce<'a> {
     /// The line is consumed and serves as backing store for the
     /// EventBody objects.
     pub fn process_line(&mut self, line: Vec<u8>) -> Result<(), CoalesceError> {
+        let filter_raw = self.settings.filter_raw_lines.is_match(&line);
+
         let skip_enriched = self.settings.translate_universal && self.settings.translate_userdb;
         let (node, typ, id, rv) = parse(line, skip_enriched).map_err(CoalesceError::Parse)?;
         let nid = (node.clone(), id);
@@ -1014,6 +1018,7 @@ impl<'a> Coalesce<'a> {
                 self.inflight.insert(nid.clone(), Event::new(node, id));
             }
             let ev = self.inflight.get_mut(&nid).unwrap();
+            ev.filter |= filter_raw;
             match ev.body.get_mut(&typ) {
                 Some(EventValues::Single(v)) => v.extend(rv),
                 Some(EventValues::Multi(v)) => v.push(rv),
@@ -1035,6 +1040,7 @@ impl<'a> Coalesce<'a> {
                 return Err(CoalesceError::DuplicateEvent(id));
             }
             let mut ev = Event::new(node, id);
+            ev.filter |= filter_raw;
             ev.body.insert(typ, EventValues::Single(rv));
             self.emit_event(ev);
         }
@@ -1472,6 +1478,24 @@ mod test {
         drop(c);
 
         Ok(())
+    }
+
+    #[test]
+    fn filter_raw() {
+        let events: Rc<RefCell<Vec<Event>>> = Rc::new(RefCell::new(vec![]));
+
+        let mut c = Coalesce::new(mk_emit_vec(&events));
+        c.settings.filter_raw_lines = regex::bytes::RegexSet::new(&[
+            "^type=SOCKADDR (?:node=\\$*? )?msg=audit\\(\\S*?\\): saddr=01002F7661722F72756E2F6E7363642F736F636B657400",
+        ])
+        .expect("failed to compile regex");
+
+        process_record(&mut c, include_bytes!("testdata/record-nscd.txt")).unwrap();
+
+        assert!(
+            events.borrow().is_empty(),
+            "nscd connect event should be filtered"
+        )
     }
 
     #[test]

--- a/src/testdata/record-nscd.txt
+++ b/src/testdata/record-nscd.txt
@@ -1,0 +1,5 @@
+type=SYSCALL msg=audit(1705071450.879:29498378): arch=c000003e syscall=42 success=no exit=-2 a0=4 a1=7ffeabb1aa00 a2=6e a3=0 items=1 ppid=1064378 pid=3736674 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts9 ses=2 comm="ls" exe="/usr/bin/ls" subj=unconfined key=(null)ARCH=x86_64 SYSCALL=connect AUID="user" UID="user" GID="user" EUID="user" SUID="user" FSUID="user" EGID="user" SGID="user" FSGID="user"
+type=SOCKADDR msg=audit(1705071450.879:29498378): saddr=01002F7661722F72756E2F6E7363642F736F636B6574000000000000000000000000000000000000000000000000000038530200000000003853020000000000001000000000000001000000050000000060020000000000006002000000000000600200000000003C4C15000000SADDR={ saddr_fam=local path=/var/run/nscd/socket }
+type=CWD msg=audit(1705071450.879:29498378): cwd="/home/user"
+type=PATH msg=audit(1705071450.879:29498378): item=0 name="/var/run/nscd/socket" nametype=UNKNOWN cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=EOE msg=audit(1705071450.879:29498378):


### PR DESCRIPTION
Example: Filter out events that invlove the glibc nscd socket (/var/run/nscd/socket):

    filter-raw = [
        "^type=SOCKADDR (?:node=\\$*? )?msg=audit\\(\\S*?\\): saddr=01002F7661722F72756E2F6E7363642F736F636B657400"
    ]

Close: #190