### PR TITLE
Implement uid-groups enrichment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
+ "serde",
  "tinyvec_macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ libc = "0.2"
 exacl = ">= 0.6"
 regex = "1"
 signal-hook = "0.3"
-tinyvec = { version = "1", features = ["alloc"] }
+tinyvec = { version = "1", features = ["alloc", "serde"] }
 
 log = "0.4"
 simple_logger = ">= 1"

--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -96,6 +96,9 @@ container = true
 # Add script context to SYSCALL execve events
 script = true
 
+# Add groups that the user (uid) is a member of. Default: true
+user-groups = true
+
 [label-process]
 
 # Audit records that contain certain keys can be reused as a label

--- a/man/laurel.8.md
+++ b/man/laurel.8.md
@@ -134,6 +134,8 @@ Options that can be configured here actually add information to events
   binary), add a `SCRIPT` entry to the `SYSCALL` record. A script is
   assumed if the first `PATH` entry does not correspond to file
   mentioned  in `SYSCALL.exe`. Default: true
+- `user-groups`: Add groups that the user ("uid") is a member of.
+  Default: true
 
 ## `[label-process]` section
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,8 @@ pub struct Enrich {
     pub pid: bool,
     #[serde(default = "true_value")]
     pub script: bool,
+    #[serde(default = "true_value", rename = "uid-groups")]
+    pub uid_groups: bool,
 }
 
 impl Default for Enrich {
@@ -101,6 +103,7 @@ impl Default for Enrich {
             container: true,
             pid: true,
             script: true,
+            uid_groups: true,
         }
     }
 }
@@ -310,6 +313,7 @@ impl Config {
             enrich_container: self.enrich.container,
             enrich_pid: self.enrich.pid,
             enrich_script: self.enrich.script,
+            enrich_uid_groups: self.enrich.uid_groups,
             proc_label_keys: self
                 .label_process
                 .label_keys


### PR DESCRIPTION
This feature adds a UID_GROUPS entry containing a list of groups that uid is a member of.

This should be useful to infer special rights associated with groups, such as sudo, docker, etc.