### PR TITLE
Make filtering first event per process optional

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -158,6 +158,12 @@ filter-null-keys = false
 #     "^type=PATH msg=\\S*? item=\\S*? name=\"/var/run/nscd[.]sock\" "
 # ]
 
+# Keep the first event observed for any given process even if it would
+# be filtered otherwise. This should only be turned off if
+# reproducible process tracking or process tree reconstruction is not
+# required.
+# keep-first-per-processes = true
+
 # What to do with filtered events? "drop" or "log" to the filterlog
 # defined above.
 filter-action = "drop"

--- a/man/laurel.8.md
+++ b/man/laurel.8.md
@@ -175,6 +175,10 @@ using them for internal processing such as process tracking.
   that contain such lines are then filtered. Default: empty
 - `filter-action`: What to do with filtered events? `drop` or `log` to the
   filterlog defined above.
+- `keep-first-per-process`: Keep the first event observed for any
+  given process even if it would be filtered otherwise. This should
+  only be turned off if reproducible process tracking or process tree
+  reconstruction is not required. Default: true
 
 # SIGNALS
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,8 @@ pub struct Filter {
     pub filter_null_keys: bool,
     #[serde(default, rename = "filter-action")]
     pub filter_action: FilterAction,
+    #[serde(default = "true_value", rename = "keep-first-per-process")]
+    pub keep_first_per_process: bool,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -346,6 +348,7 @@ impl Config {
                 .collect(),
             filter_null_keys: self.filter.filter_null_keys,
             filter_raw_lines: self.filter.filter_raw_lines.clone(),
+            filter_first_per_process: !self.filter.keep_first_per_process,
         }
     }
 }

--- a/src/testdata/record-syscall-key.txt
+++ b/src/testdata/record-syscall-key.txt
@@ -1,3 +1,6 @@
-type=SYSCALL msg=audit(1628602815.266:2366): arch=c000003e syscall=59 success=yes exit=0 a0=2557470 a1=247b510 a2=2565820 a3=5bb items=2 ppid=3193 pid=6382 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="cat" exe="/usr/bin/cat" key="filter-this"
-type=SYSCALL msg=audit(1628602815.266:2366): arch=c000003e syscall=59 success=yes exit=0 a0=2557470 a1=247b510 a2=2565820 a3=5bb items=2 ppid=3193 pid=6382 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="cat" exe="/usr/bin/cat" key="this-too"
+type=SYSCALL msg=audit(1628602815.266:2365): arch=c000003e syscall=59 success=yes exit=0 a0=2557470 a1=247b510 a2=2565820 a3=5bb items=2 ppid=3193 pid=6382 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="cat" exe="/usr/bin/cat" key="filter-this"
+type=EOE msg=audit(1628602815.266:2365):
+type=SYSCALL msg=audit(1628602815.266:2366): arch=c000003e syscall=0 success=yes exit=0 a0=2557470 a1=247b510 a2=2565820 a3=5bb items=2 ppid=3193 pid=6382 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="cat" exe="/usr/bin/cat" key="filter-this"
 type=EOE msg=audit(1628602815.266:2366):
+type=SYSCALL msg=audit(1628602815.266:2367): arch=c000003e syscall=0 success=yes exit=0 a0=2557470 a1=247b510 a2=2565820 a3=5bb items=2 ppid=3193 pid=6382 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="cat" exe="/usr/bin/cat" key="this-too"
+type=EOE msg=audit(1628602815.266:2367):

--- a/src/testdata/record-syscall-nullkey.txt
+++ b/src/testdata/record-syscall-nullkey.txt
@@ -1,9 +1,9 @@
-type=PROCTITLE msg=audit(1678282381.452:102337): proctitle="(systemd)"
+type=SYSCALL msg=audit(1678282381.452:102336): arch=c000003e syscall=59 success=yes exit=5 a0=9 a1=7ffd4ac563d1 a2=5 a3=0 items=0 ppid=1 pid=3489504 auid=34005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=15589 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
+type=EOE msg=audit(1678282381.452:102336): 
+
 type=SYSCALL msg=audit(1678282381.452:102337): arch=c000003e syscall=1 success=yes exit=5 a0=9 a1=7ffd4ac563d1 a2=5 a3=0 items=0 ppid=1 pid=3489504 auid=34005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=15589 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
 type=EOE msg=audit(1678282381.452:102337): 
-type=PROCTITLE msg=audit(1678282320.958:102262): proctitle=536f6d6552616e646f6d50726f63657373
-type=SYSCALL msg=audit(1678282320.958:102262): arch=c000003e syscall=1 success=yes exit=5 a0=3 a1=7ffd9f4453e0 a2=5 a3=0 items=0 ppid=8750 pid=3483623 auid=34025 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=15584 comm="sshd" exe="/bin/sshd" subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)
-type=EOE msg=audit(1678282320.958:102262): 
+
 type=PROCTITLE msg=audit(1678283440.683:225): proctitle=536f6d6552616e646f6d50726f63657373
 type=PATH msg=audit(1678283440.683:225): item=0 name="/proc/2414/root/usr/bin/su" inode=156161 dev=fd:00 mode=0104755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:su_exec_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0
 type=SYSCALL msg=audit(1678283440.683:225): arch=c000003e syscall=4 success=yes exit=0 a0=7edd0caa2e7e0 a1=7345b64adba0 a2=7ff9874adba0 a3=feefeffefefefeff items=1 ppid=816 pid=818 auid=4292467295 uid=502 gid=502 euid=502 suid=502 fsuid=502 egid=502 sgid=502 fsgid=502 tty=(none) ses=4296967295 comm="cat" exe="/usr/bin/cat" subj=system_u:system_r:system_t:s0 key=(null)


### PR DESCRIPTION
The first observed event in a process is special because it is used to uniquely identify that process when enriching PIDs. It is therefore useful to keep this first event in the main log.