### PR TITLE
Updated INSTALL.md to include the re-labeling for the auditd plugin.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,7 +44,7 @@ $ sudo install -m755 laurel /usr/local/sbin/laurel
     ``` console
     $ make -C contrib/selinux
     $ sudo semodule -i contrib/selinux/laurel.pp
-    $ sudo restorecon -v -R -F /usr/local/sbin/laurel /etc/laurel /var/log/laurel
+    $ sudo restorecon -v -R -F /usr/local/sbin/laurel /etc/laurel /var/log/laurel /etc/audit/plugins.d/laurel.conf
     ```
 - Tell _auditd(8)_ to re-evaluate its configuration:
     ``` console


### PR DESCRIPTION
Hey there,

first, many thanks for the great tool!

I encountered an error when installing laurel on a Fedora 40 machine.

Steps I took:
- Download the released binary
- Follow the installation guide (including cloning this repo and installing the selinux policy)

Sadly I got the following error when checking on auditd:
```
Jun 10 17:40:03 fedora auditd[1896]: Error opening /etc/audit/plugins.d//laurel.conf (Permission denied)
Jun 10 17:40:03 fedora auditd[1896]: Skipping laurel.conf plugin due to errors
```

The permissions on the plugin file looked like this:
```
[root@fedora plugins.d]# ls -lZ
total 8
-rwxr-----. 1 root root unconfined_u:object_r:user_home_t:s0 129 Jun 10 17:25 laurel.conf
-rw-r--r--. 1 root root system_u:object_r:auditd_etc_t:s0    170 Jan 31 01:00 sedispatch.conf
```

After running the `restorecon -v -R -F /etc/audit/plugins.d/laurel.conf` command the file is labeled how it should be:
```
[root@fedora plugins.d]# ls -lZ
total 8
-rwxr-----. 1 root root system_u:object_r:auditd_etc_t:s0 129 Jun 10 17:25 laurel.conf
-rw-r--r--. 1 root root system_u:object_r:auditd_etc_t:s0 170 Jan 31 01:00 sedispatch.conf
```

and after restarting auditd, it shows that the plugin was successfully started:
```
Jun 10 17:47:12 fedora laurel[8929]: Started /usr/local/sbin/laurel running version 0.6.2
Jun 10 17:47:12 fedora laurel[8929]: Running with EUID 968 using config (user=_laurel directory=/var/log/laurel statusreport-period=0 file=audit.log users=wazuh size=5000000 generations=10)
```

I adapted the INSTALL.md to reflect this.