### PR TITLE
If 'file' is set to stdout, optionally specify a script to directly send to stdin.

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -15,11 +15,11 @@ input = "stdin"
 # marker = "correct-horse-battery-staple"
 
 [auditlog]
-# Base file name for the JSONL-based log file. Set to "-" to log to stdout. In this case 
-# other log file related settings will be ignored.
+# Base file name for the JSONL-based log file. Set to "-" to log to stdout. You can set
+# it to send the stdout directly to another script or process by specifying that script
+# or process, preceeded with a pipe. ex. "| /usr/local/script.sh"
+# In these cases other log file related settings will be ignored.
 file = "audit.log"
-# If 'file' is set to stdout, optionally specify a script to directly send to stdin.
-# stdoutprocess = "/usr/local/script.sh"
 # Rotate when log file reaches this size (in bytes)
 size = 5000000
 # When rotating, keep this number of generations around

--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -18,6 +18,8 @@ input = "stdin"
 # Base file name for the JSONL-based log file. Set to "-" to log to stdout. In this case 
 # other log file related settings will be ignored.
 file = "audit.log"
+# If 'file' is set to stdout, optionally specify a script to directly send to stdin.
+# stdoutprocess = "/usr/local/script.sh"
 # Rotate when log file reaches this size (in bytes)
 size = 5000000
 # When rotating, keep this number of generations around

--- a/src/bin/laurel/main.rs
+++ b/src/bin/laurel/main.rs
@@ -99,27 +99,22 @@ impl Logger {
 
     fn new(def: &Logfile, dir: &Path) -> anyhow::Result<Self> {
         match &def.file {
-            p if p.as_os_str() == "-" => {
-            if let Some(command) = &def.stdoutprocess  {
-                // If `def.stdoutprocess ` is defined, spawn the process and write to its stdin
-                let mut child = std::process::Command::new(command)
+            p if p.as_os_str().to_str().unwrap().starts_with('|') => {
+				let command = &p.as_os_str().to_str().unwrap()[1..].trim_start();
+				let mut child = std::process::Command::new(command)
                     .stdin(std::process::Stdio::piped())
                     .spawn()
                     .map_err(|e| anyhow!("failed to start process: {}", e))?;
-                
                 let stdin = child.stdin.take().ok_or_else(|| anyhow!("failed to open stdin"))?;
                 Ok(Logger {
                     prefix: def.line_prefix.clone(),
                     output: BufWriter::new(Box::new(stdin)),
                 })
-            } else {
-                // If no stdoutprocess is defined, fall back to writing to stdout
-                Ok(Logger {
-                    prefix: def.line_prefix.clone(),
-                    output: BufWriter::new(Box::new(io::stdout())),
-                    })
-                }
-            },
+			},
+			p if p.as_os_str() == "-" => Ok(Logger {
+				prefix: def.line_prefix.clone(),
+                output: BufWriter::new(Box::new(io::stdout())),
+            }),
             p if p.has_root() && p.parent().is_none() => Err(anyhow!(
                 "invalid file directory={} file={}",
                 dir.to_string_lossy(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ use crate::label_matcher::LabelMatcher;
 pub struct Logfile {
     #[serde(default)]
     pub file: PathBuf,
-    pub stdoutprocess: Option<PathBuf>,
     #[serde(rename = "read-users")]
     pub users: Option<Vec<String>>,
     pub size: Option<u64>,
@@ -254,7 +253,6 @@ impl Default for Config {
             marker: None,
             auditlog: Logfile {
                 file: "audit.log".into(),
-                stdoutprocess: None,
                 users: None,
                 size: Some(10 * 1024 * 1024),
                 generations: Some(5),
@@ -262,7 +260,6 @@ impl Default for Config {
             },
             filterlog: Logfile {
                 file: "filtered.log".into(),
-                stdoutprocess: None,
                 users: None,
                 size: Some(10 * 1024 * 1024),
                 generations: Some(5),

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,6 +254,7 @@ impl Default for Config {
             marker: None,
             auditlog: Logfile {
                 file: "audit.log".into(),
+                stdoutprocess: None,
                 users: None,
                 size: Some(10 * 1024 * 1024),
                 generations: Some(5),

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use crate::label_matcher::LabelMatcher;
 pub struct Logfile {
     #[serde(default)]
     pub file: PathBuf,
+    pub stdoutprocess: Option<PathBuf>,
     #[serde(rename = "read-users")]
     pub users: Option<Vec<String>>,
     pub size: Option<u64>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,6 +262,7 @@ impl Default for Config {
             },
             filterlog: Logfile {
                 file: "filtered.log".into(),
+                stdoutprocess: None,
                 users: None,
                 size: Some(10 * 1024 * 1024),
                 generations: Some(5),


### PR DESCRIPTION
Added `stdoutprocess` to config file to optionally send stdout directly to another script's stdin, when stdout is enabled.