### PR TITLE
Fix process tracking confusion, inadvertent proc table modification

### DIFF
--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -756,7 +756,7 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                         let pr = if syscall_is_exec {
                             None
                         } else {
-                            self.processes.get_or_retrieve(proc.pid)
+                            self.processes.get_pid(proc.pid)
                         };
                         match pr {
                             Some(pr) if proc.ppid == pr.ppid && proc.exe == pr.exe => {


### PR DESCRIPTION
For non-`execve*` syscalls, we consult the process table to find out whether we have seen the process before or whether a new entry needs to be added to the process table.

The process table lookup was done using `.get_or_retrieve` which might modify the process table by filling in a missing entry from `/proc/$PID/` and subsequently returning a misleading result that contained only a process `START_TIME` instead of an `EVENT_ID`.

This problem would cause the event ID to be ignored and break process label inheritance, particularly in double-`fork` scenarios common in shell scripts. Since a race can't be avoided in accessing `/proc`, reproducing this bug was quite unreliable.

To fix this, we simply use `.get_pid` which will not modify the process table for its lookup.