### PR TITLE
Add option to prefix enriched fields instead of capitalizing them

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -109,6 +109,13 @@ script = true
 # Add groups that the user (uid) is a member of. Default: true
 user-groups = true
 
+# Add a prefix to enriched fields; this may be useful if logs are
+# consumed by analysis software that doesn't properly understand
+# uppercase and lowercase JSON object fields as identical. This
+# setting has no affect enriched fields passed in from auditd.
+# Default: unset
+# prefix = "enriched_"
+
 [label-process]
 
 # Audit records that contain certain keys can be reused as a label

--- a/man/laurel.8.md
+++ b/man/laurel.8.md
@@ -140,6 +140,11 @@ Options that can be configured here actually add information to events
   mentioned  in `SYSCALL.exe`. Default: true
 - `user-groups`: Add groups that the user ("uid") is a member of.
   Default: true
+- `prefix`: Add a prefix to enriched fields; this may be useful if
+  logs are onsumed by analysis software that doesn't properly
+  understand uppercase and lowercase JSON object fields as identical.
+  This setting does not affect enriched fields passed in from
+  `auditd(8)`. Default: unset
 
 ## `[label-process]` section
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,8 @@ pub struct Enrich {
     pub script: bool,
     #[serde(default = "true_value", rename = "uid-groups")]
     pub uid_groups: bool,
+    #[serde(default)]
+    pub prefix: Option<String>,
 }
 
 impl Default for Enrich {
@@ -108,6 +110,7 @@ impl Default for Enrich {
             pid: true,
             script: true,
             uid_groups: true,
+            prefix: None,
         }
     }
 }
@@ -335,6 +338,7 @@ impl Config {
             enrich_pid: self.enrich.pid,
             enrich_script: self.enrich.script,
             enrich_uid_groups: self.enrich.uid_groups,
+            enrich_prefix: self.enrich.prefix.clone(),
             proc_label_keys: self
                 .label_process
                 .label_keys


### PR DESCRIPTION
This seems useful for mis-designed log analysis software that treats JSNO object keys as case-insensitive.

Close #244