### PR TITLE
Add filter-sockaddr feature for filtering IP addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +417,7 @@ dependencies = [
  "getopts",
  "gperftools",
  "indexmap",
+ "ipnetwork",
  "lazy_static",
  "libc",
  "linux-audit-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ faster-hex = ">= 0.9"
 linux-audit-parser = "0.2.6"
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 serde_bytes = "0.11.15"
+ipnetwork = "0.21.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "0.5"

--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -185,6 +185,17 @@ propagate-labels = [ "software_mgmt", "amazon-ssm-agent" ]
 
 filter-null-keys = false
 
+# Filter events that contain SOCKADDR entries matching CIDR and/or ports
+# Valid expresions:
+# - "ipv4"
+# - "ipv6", "[ipv6]"
+# - "ipv4:port"
+# - "ipv4/bits:port"
+# - "[ipv6]:port"
+# - "[ipv6/bits]:port"
+# - "*:port"
+# filter-sockaddr = [ "127.0.0.1", "192.168.0.0/24:22", "::/64", "[2a00:1450:4001:82f::200e]:443", "*:111" ]
+
 # Filter events that were constructed from input lines matching these
 # regular expressions
 # filter-raw-lines = [

--- a/man/laurel.8.md
+++ b/man/laurel.8.md
@@ -210,6 +210,15 @@ using them for internal processing such as process tracking.
 - `filter-null-keys`: Filter events without specified key. Default: false
 - `filter-labels`: A list of strings that are matched against process
   labels. Default: empty
+- `filter-sockaddr`: Filter events that contain SOCKADDR entries
+  matching CIDR and/or ports. IPv4 and IPv6 addresses with optional
+  bitmask and port numbers or plain port numbers can be specified. Examples:
+   - `127.0.0.1`
+   - `192.168.0.0/24:22`
+   - `::/64`
+   - `[2a00:1450:4001:82f::200e]:443`
+   - `*:111`
+  Default: empty list
 - `filter-raw-lines`: A list of regular expression that are matched
   against individual input lines as written by `auditd(8)`. Events
   that contain such lines are then filtered. Default: empty

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use serde::{
 
 use crate::coalesce::Settings;
 use crate::label_matcher::LabelMatcher;
+use crate::sockaddr::SocketAddrMatcher;
 
 fn default_state_file() -> Option<PathBuf> {
     Some(Path::new("state").into())
@@ -234,6 +235,8 @@ pub struct Filter {
     pub filter_raw_lines: regex::bytes::RegexSet,
     #[serde(default, rename = "filter-null-keys")]
     pub filter_null_keys: bool,
+    #[serde(default, rename = "filter-sockaddr")]
+    pub filter_sockaddr: Vec<SocketAddrMatcher>,
     #[serde(default, rename = "filter-action")]
     pub filter_action: FilterAction,
     #[serde(default = "true_value", rename = "keep-first-per-process")]
@@ -431,6 +434,7 @@ impl Config {
                 .map(|s| s.as_bytes().to_vec())
                 .collect(),
             filter_null_keys: self.filter.filter_null_keys,
+            filter_sockaddr: self.filter.filter_sockaddr.clone(),
             filter_raw_lines: self.filter.filter_raw_lines.clone(),
             filter_first_per_process: !self.filter.keep_first_per_process,
         }

--- a/src/testdata/record-connect.txt
+++ b/src/testdata/record-connect.txt
@@ -1,0 +1,6 @@
+type=SYSCALL msg=audit(1723819442.459:2482681): arch=c000003e syscall=42 success=yes exit=0 a0=8 a1=5556eca10aa0 a2=10 a3=4 items=0 ppid=1074250 pid=1074252 auid=4294967295 uid=48 gid=48 euid=48 suid=48 fsuid=48 egid=48 sgid=48 fsgid=48 tty=(none) ses=4294967295 comm="php" exe="/usr/bin/php" key=(null)
+type=SOCKADDR msg=audit(1723819442.459:2482681): saddr=02002BCB7F0000010000000000000000
+type=EOE msg=audit(1723819442.459:2482681): 
+type=SYSCALL msg=audit(1723819442.459:2482682): arch=c000003e syscall=42 success=no exit=-115 a0=8 a1=5556ec9f92f0 a2=1c a3=ffffffff items=0 ppid=1074250 pid=1074252 auid=4294967295 uid=48 gid=48 euid=48 suid=48 fsuid=48 egid=48 sgid=48 fsgid=48 tty=(none) ses=4294967295 comm="php" exe="/usr/bin/php" key=(null)
+type=SOCKADDR msg=audit(1723819442.459:2482682): saddr=0A002BCB000000000000000000000000000000000000000100000000
+type=EOE msg=audit(1723819442.459:2482682): 


### PR DESCRIPTION
Filtering `bind`, `connect` etc. based on the address is not possible using audit rules. This feature enables Laurel to filter out useless/uninteresting events.