### PR TITLE
selinux: add additional laurel binary path

### DIFF
--- a/contrib/selinux/laurel.fc
+++ b/contrib/selinux/laurel.fc
@@ -1,5 +1,6 @@
 /usr/local/sbin/laurel			gen_context(system_u:object_r:laurel_exec_t,s0)
 /usr/sbin/laurel			gen_context(system_u:object_r:laurel_exec_t,s0)
+/usr/bin/laurel 			gen_context(system_u:object_r:laurel_exec_t,s0)
 /sbin/laurel				gen_context(system_u:object_r:laurel_exec_t,s0)
 /etc/laurel(/.*)?			gen_context(system_u:object_r:laurel_etc_t,s0)
 /var/log/laurel(/.*)?			gen_context(system_u:object_r:laurel_log_t,s0)


### PR DESCRIPTION
SLES16 uses a directive `/usr/sbin = /usr/bin` which prevents the existing rules to match on /usr/sbin/laurel.