### PR TITLE
added glob_match and updated env var resolve to be done with glob_match to support wildcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,12 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "glob-match"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
-
-[[package]]
 name = "gperftools"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,7 +431,6 @@ dependencies = [
  "exacl",
  "faster-hex",
  "getopts",
- "glob-match",
  "gperftools",
  "indexmap",
  "ipnetwork",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ toml = ">= 0.5"
 nix = { version = ">= 0.26", features = ["user", "fs", "time", "process", "signal"]}
 libc = "0.2"
 exacl = ">= 0.6"
-glob-match = "0.2"
 regex = "1"
 signal-hook = "0.3"
 tinyvec = { version = "1", features = ["alloc", "serde"] }

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -831,10 +831,12 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
         ) {
             if let Ok(vars) =
                 procfs::get_environ(proc.pid, |k| {
-                    let name = String::from_utf8_lossy(k);
                     self.settings.execve_env.iter().any(|pattern| {
-                        let pat = String::from_utf8_lossy(pattern);
-                        glob_match::glob_match(&pat, &name)
+                        if let Some(prefix) = pattern.strip_suffix(b"*") {
+                            k.starts_with(prefix)
+                        } else {
+                            k == pattern.as_slice()
+                        }
                     })
                 })
             {


### PR DESCRIPTION
Examples for env var configuration that the PR support:
* `AWS_*` - to print all AWS env vars
* `*` - to print ALL env vars

fully tested, of course.
`glob_match` has no dependencies.

This helps in cases you don't know which env vars to expect, but you know the "range" of the env vars you want to audit.