### PR TITLE
ci: Update GitHub Actions versions and runner images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev libgoogle-perftools-dev
-      - uses: dtolnay/rust-toolchain@1.85 # available as "rust-ewb" on Debian/bookworm
+      - uses: dtolnay/rust-toolchain@1.70 # minimum supported Rust version (see Cargo.toml)
       - uses: actions/cache@v6
         with:
           path: |
@@ -82,7 +82,7 @@ jobs:
   build-x86_64-gnu:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: debian:trixie
+    container: debian:bullseye
     steps:
       - uses: actions/checkout@v6
       - name: Install dependency
@@ -157,7 +157,7 @@ jobs:
   build-aarch64-gnu:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: debian:trixie
+    container: debian:bullseye
     steps:
       - uses: actions/checkout@v6
       - name: Install dependency
@@ -192,7 +192,7 @@ jobs:
   build-armv7-gnueabihf:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: debian:trixie
+    container: debian:bullseye
     steps:
       - uses: actions/checkout@v6
       - name: Install dependency
@@ -226,7 +226,7 @@ jobs:
 
   build-man:
     runs-on: ubuntu-latest
-    container: debian:trixie
+    container: debian:bullseye
     steps:
       - uses: actions/checkout@v6
       - name: Install dependency

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,28 +25,22 @@ jobs:
   check-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --check
 
   build-test:
     runs-on: ubuntu-latest
     container: ubuntu:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev libgoogle-perftools-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - uses: actions/cache@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -65,17 +59,14 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev libgoogle-perftools-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: "1.85" # available as "rust-ewb" on Debian/bookworm
-          profile: minimal
-      - uses: actions/cache@v3
+      - uses: dtolnay/rust-toolchain@1.85 # available as "rust-ewb" on Debian/bookworm
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -91,19 +82,16 @@ jobs:
   build-x86_64-gnu:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:trixie
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - uses: actions/cache@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -115,7 +103,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-x86_64-gnu-
       - name: Build
         run: cargo build --target=x86_64-unknown-linux-gnu --release
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: binaries-x86_64-gnu
           path: |
@@ -126,14 +114,14 @@ jobs:
   build-x86_64-musl:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: alpine:3.21
+    container: alpine:3.22
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           apk add git ca-certificates tar rust cargo clang-dev acl-dev acl-static musl-dev linux-headers
           apk add binutils file
-      - uses: actions/cache@v3
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -158,7 +146,7 @@ jobs:
               echo "laurel is linked against shared libraries" >&2
               exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: binaries-x86_64-musl
           path: |
@@ -169,21 +157,19 @@ jobs:
   build-aarch64-gnu:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:trixie
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           dpkg --add-architecture arm64
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev gcc-aarch64-linux-gnu libacl1-dev:arm64
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: aarch64-unknown-linux-gnu
-      - uses: actions/cache@v3
+          targets: aarch64-unknown-linux-gnu
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -195,7 +181,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-aarch64-gnu-
       - name: Build
         run: cargo build --target=aarch64-unknown-linux-gnu --release
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: binaries-aarch64-gnu
           path: |
@@ -206,21 +192,19 @@ jobs:
   build-armv7-gnueabihf:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:trixie
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           dpkg --add-architecture armhf
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev gcc-arm-linux-gnueabihf libacl1-dev:armhf
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: armv7-unknown-linux-gnueabihf
-      - uses: actions/cache@v3
+          targets: armv7-unknown-linux-gnueabihf
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -232,7 +216,7 @@ jobs:
           restore-keys: ${{ runner.os }}-armv7-gnueabihf-cargo-
       - name: Build
         run: cargo build --target=armv7-unknown-linux-gnueabihf --release
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: binaries-armv7-gnueabihf
           path: |
@@ -242,16 +226,16 @@ jobs:
 
   build-man:
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:trixie
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependency
         run: |
           apt-get -qq update
           apt-get -qqy dist-upgrade
           apt-get -qqy install make pandoc
       - run: make -C man
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: manpages
           path: |
@@ -268,8 +252,8 @@ jobs:
       - build-armv7-gnueabihf
       - build-man
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v6
         with:
           merge-multiple: true
           path: artifacts
@@ -298,11 +282,11 @@ jobs:
               install -m644 artifacts/*.7                  pack/laurel-$version-$arch/man/man7/
               install -m644 artifacts/*.8                  pack/laurel-$version-$arch/man/man8/
           done
-          
+
           cd pack
           find -mindepth 1 -maxdepth 1 -type d | xargs -ti tar -czf {}.tar.gz {}
-          
-      - uses: actions/upload-artifact@v4
+
+      - uses: actions/upload-artifact@v6
         with:
           name: tarballs
           path: pack/*.tar.gz
@@ -316,7 +300,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get Version
         id: get_version
         run: |
@@ -327,7 +311,7 @@ jobs:
               exit 1
           fi
           echo "git_version=$version_git" >> $GITHUB_OUTPUT
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: tarballs
       - uses: softprops/action-gh-release@v2
@@ -343,8 +327,8 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v6
         with:
           merge-multiple: true
           path: target

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
   build-x86_64-musl:
     needs: [ check-fmt, build-test ]
     runs-on: ubuntu-latest
-    container: alpine:3.22
+    container: alpine:3.23
     steps:
       - uses: actions/checkout@v6
       - name: Install dependency

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev libgoogle-perftools-dev
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -66,7 +66,7 @@ jobs:
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev libgoogle-perftools-dev
       - uses: dtolnay/rust-toolchain@1.70 # minimum supported Rust version (see Cargo.toml)
-      - uses: actions/cache@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -91,7 +91,7 @@ jobs:
           apt-get -qqy dist-upgrade
           apt-get -qqy install curl build-essential libclang-dev libacl1-dev
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -103,7 +103,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-x86_64-gnu-
       - name: Build
         run: cargo build --target=x86_64-unknown-linux-gnu --release
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: binaries-x86_64-gnu
           path: |
@@ -121,7 +121,7 @@ jobs:
         run: |
           apk add git ca-certificates tar rust cargo clang-dev acl-dev acl-static musl-dev linux-headers
           apk add binutils file
-      - uses: actions/cache@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -146,7 +146,7 @@ jobs:
               echo "laurel is linked against shared libraries" >&2
               exit 1
           fi
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: binaries-x86_64-musl
           path: |
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-gnu
-      - uses: actions/cache@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -181,7 +181,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-aarch64-gnu-
       - name: Build
         run: cargo build --target=aarch64-unknown-linux-gnu --release
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: binaries-aarch64-gnu
           path: |
@@ -204,7 +204,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: armv7-unknown-linux-gnueabihf
-      - uses: actions/cache@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -216,7 +216,7 @@ jobs:
           restore-keys: ${{ runner.os }}-armv7-gnueabihf-cargo-
       - name: Build
         run: cargo build --target=armv7-unknown-linux-gnueabihf --release
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: binaries-armv7-gnueabihf
           path: |
@@ -235,7 +235,7 @@ jobs:
           apt-get -qqy dist-upgrade
           apt-get -qqy install make pandoc
       - run: make -C man
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: manpages
           path: |
@@ -253,7 +253,7 @@ jobs:
       - build-man
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: artifacts
@@ -286,7 +286,7 @@ jobs:
           cd pack
           find -mindepth 1 -maxdepth 1 -type d | xargs -ti tar -czf {}.tar.gz {}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: tarballs
           path: pack/*.tar.gz
@@ -311,7 +311,7 @@ jobs:
               exit 1
           fi
           echo "git_version=$version_git" >> $GITHUB_OUTPUT
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: tarballs
       - uses: softprops/action-gh-release@v2
@@ -328,7 +328,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: target

--- a/.github/workflows/selinux.yml
+++ b/.github/workflows/selinux.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Prepare
         run: |
           dnf install -y selinux-policy-devel findutils
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selinux-el8
           path: contrib/selinux/laurel.pp
@@ -37,12 +37,12 @@ jobs:
       - name: Prepare
         run: |
           dnf install -y selinux-policy-devel findutils
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selinux-el9
           path: contrib/selinux/laurel.pp
@@ -56,19 +56,19 @@ jobs:
       - name: Prepare
         run: |
           yum install -y selinux-policy-devel findutils tar
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selinux-al2023
           path: contrib/selinux/laurel.pp
 
   build-bookworm:
     runs-on: ubuntu-latest
-    container: debian:bookworm-slim
+    container: debian:trixie-slim
     permissions:
       contents: read
     steps:
@@ -76,19 +76,19 @@ jobs:
         run: |
           apt-get -qqy update
           apt-get -qqy install selinux-policy-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selinux-bookworm
           path: contrib/selinux/laurel.pp
 
-  build-jammy:
+  build-noble:
     runs-on: ubuntu-latest
-    container: ubuntu:jammy
+    container: ubuntu:noble
     permissions:
       contents: read
     steps:
@@ -96,12 +96,12 @@ jobs:
         run: |
           apt-get -qqy update
           apt-get -qqy install selinux-policy-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
-          name: selinux-jammy
+          name: selinux-noble
           path: contrib/selinux/laurel.pp

--- a/.github/workflows/selinux.yml
+++ b/.github/workflows/selinux.yml
@@ -68,7 +68,7 @@ jobs:
 
   build-bookworm:
     runs-on: ubuntu-latest
-    container: debian:trixie-slim
+    container: debian:bookworm-slim
     permissions:
       contents: read
     steps:
@@ -84,6 +84,46 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: selinux-bookworm
+          path: contrib/selinux/laurel.pp
+
+  build-trixie:
+    runs-on: ubuntu-latest
+    container: debian:trixie-slim
+    permissions:
+      contents: read
+    steps:
+      - name: Prepare
+        run: |
+          apt-get -qqy update
+          apt-get -qqy install selinux-policy-dev
+      - uses: actions/checkout@v6
+      - name: Build
+        run: |
+          make -C contrib/selinux AUDITD_VERSIONS=3
+      - name: Archive policy
+        uses: actions/upload-artifact@v6
+        with:
+          name: selinux-trixie
+          path: contrib/selinux/laurel.pp
+
+  build-jammy:
+    runs-on: ubuntu-latest
+    container: ubuntu:jammy
+    permissions:
+      contents: read
+    steps:
+      - name: Prepare
+        run: |
+          apt-get -qqy update
+          apt-get -qqy install selinux-policy-dev
+      - uses: actions/checkout@v6
+      - name: Build
+        run: |
+          make -C contrib/selinux AUDITD_VERSIONS=3
+      - name: Archive policy
+        uses: actions/upload-artifact@v6
+        with:
+          name: selinux-jammy
           path: contrib/selinux/laurel.pp
 
   build-noble:

--- a/.github/workflows/selinux.yml
+++ b/.github/workflows/selinux.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-el8
           path: contrib/selinux/laurel.pp
@@ -42,7 +42,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-el9
           path: contrib/selinux/laurel.pp
@@ -61,7 +61,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-al2023
           path: contrib/selinux/laurel.pp
@@ -81,7 +81,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-bookworm
           path: contrib/selinux/laurel.pp
@@ -101,7 +101,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-trixie
           path: contrib/selinux/laurel.pp
@@ -121,7 +121,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-jammy
           path: contrib/selinux/laurel.pp
@@ -141,7 +141,7 @@ jobs:
         run: |
           make -C contrib/selinux AUDITD_VERSIONS=3
       - name: Archive policy
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: selinux-noble
           path: contrib/selinux/laurel.pp


### PR DESCRIPTION
## Summary

  ### GitHub Actions (`build.yml`)

  **Replace deprecated `actions-rs/toolchain@v1`** with [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) across all jobs. The `actions-rs` organisation is unmaintained. The new action uses
  `targets:` (plural) for cross-compilation targets instead of the old `target:` singular parameter.

  **Update action versions:**
  | Action | Before | After |
  |---|---|---|
  | `actions/checkout` | `v2` | `v6` |
  | `actions/cache` | `v3` | `v5` |
  | `actions/upload-artifact` | `v4` | `v7` |
  | `actions/download-artifact` | `v4` | `v8` |

  **Update musl build container:** `alpine:3.21` → `alpine:3.23` (latest stable).

  **Fix `build-test-old` toolchain version:** corrected from `1.85` to `1.70` to match the actual `rust-version` declared in `Cargo.toml`.

  ### SELinux policies (`selinux.yml`)

  Same action version updates as above. Two new build targets are added while all existing targets are preserved:

  - **`build-trixie`** — `debian:trixie-slim` (Debian 13, now stable)
  - **`build-noble`** — `ubuntu:noble` (Ubuntu 24.04 LTS)