### PR TITLE
Remove support for building for non-Linux systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
           key: "${{ runner.os }}-test-cargo-${{ hashFiles('**/Cargo.lock') }}"
           restore-keys: ${{ runner.os }}-test-cargo-
       - run: cargo build
-      - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo bench --no-run
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ ipnetwork = "0.21.1"
 aho-corasick = "1.1"
 memchr = "2.8.1"
 itertools = "0.14.0"
-
-[target.'cfg(target_os = "linux")'.dependencies]
 caps = "0.5"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -88,7 +88,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     fs::write(dest_path, buf)?;
 
-    #[cfg(target_os = "linux")]
     bindgen::Builder::default()
         .header("src/sockaddr.h")
         .allowlist_type("^sockaddr_.*")
@@ -101,7 +100,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=const.rs.in");
-    #[cfg(target_os = "linux")]
     println!("cargo:rerun-if-changed=src/sockaddr.h");
 
     Ok(())

--- a/src/bin/laurel/main.rs
+++ b/src/bin/laurel/main.rs
@@ -23,10 +23,8 @@ use nix::sys::{
     sysinfo::sysinfo,
 };
 use nix::unistd::{chown, execve, Group, Uid, User};
-#[cfg(target_os = "linux")]
 use nix::unistd::{setresgid, setresuid};
 
-#[cfg(target_os = "linux")]
 use caps::{securebits::set_keepcaps, CapSet, Capability};
 
 use serde::{Deserialize, Serialize};
@@ -88,7 +86,6 @@ impl AddAssign for Stats {
 /// - CAP_DAC_READ_SEARCH+CAP_SYS_PTRACE are required for accessing
 ///   environment variables from arbitrary processes
 ///   (/proc/$PID/environ).
-#[cfg(target_os = "linux")]
 fn drop_privileges(runas_user: &User) -> anyhow::Result<()> {
     set_keepcaps(true)?;
     let uid = runas_user.uid;
@@ -477,10 +474,8 @@ fn run_app() -> Result<(), anyhow::Error> {
     } else if runas_user.uid.is_root() {
         log::warn!("Not dropping privileges -- no user configured");
     } else {
-        #[cfg(target_os = "linux")]
         drop_privileges(&runas_user)?;
     }
-    #[cfg(target_os = "linux")]
     if let Err(e) = caps::clear(None, CapSet::Ambient) {
         log::warn!("could not set ambient capabilities: {e}");
     }
@@ -603,7 +598,6 @@ fn run_app() -> Result<(), anyhow::Error> {
                 .map(|(k, v)| CString::new(format!("{k}={v}")).unwrap())
                 .collect();
 
-            #[cfg(target_os = "linux")]
             {
                 let capabilities =
                     [Capability::CAP_SYS_PTRACE, Capability::CAP_DAC_READ_SEARCH].into();

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -2,11 +2,9 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Display};
 use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 use std::os::unix::fs::MetadataExt;
 use std::str::FromStr;
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 use faster_hex::hex_string;
 
 use linux_audit_parser::*;
@@ -16,13 +14,10 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 use crate::constants::{ARCH_NAMES, SYSCALL_NAMES, URING_OPS};
 use crate::env_matcher::EnvMatcher;
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 use crate::hash::Sha256Writer;
 use crate::label_matcher::LabelMatcher;
 use crate::proc::{self, ContainerInfo, ProcTable, Process, ProcessKey};
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 use crate::procfs;
-#[cfg(target_os = "linux")]
 use crate::sockaddr::{SocketAddr, SocketAddrMatcher};
 use crate::types::*;
 use crate::userdb::UserDB;
@@ -168,14 +163,12 @@ pub struct State<'ev> {
     userdb: UserDB,
 }
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 /// LRU cache for exe hashes, keyed by (dev, inode, mtime_nsec)
 struct ExeHashCache {
     max_entries: usize,
     entries: indexmap::IndexMap<(u64, u64, i64), [u8; 32]>,
 }
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 impl ExeHashCache {
     fn new(max_entries: usize) -> Self {
         ExeHashCache {
@@ -212,7 +205,6 @@ pub struct Coalesce<'a, 'ev> {
     /// Output function
     emit_fn: Box<dyn 'a + FnMut(&Event<'ev>)>,
     /// Cache for exe hashes
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     exe_hash_cache: Option<ExeHashCache>,
 
     pub settings: Settings,
@@ -224,7 +216,6 @@ const EXPIRE_DONE_TIMEOUT: u64 = 120_000;
 
 /// generate translation of SocketAddr enum to a format similar to
 /// what auditd log_format=ENRICHED produces
-#[cfg(target_os = "linux")]
 fn add_translated_socketaddr(rv: &mut Body, sa: SocketAddr) {
     let mut m: Vec<(Key, Value)> = Vec::with_capacity(5);
     match sa {
@@ -348,7 +339,6 @@ impl UserGroupIDs {
 ///
 /// As an extra sanity check, exe is compared with normalized
 /// PATH.name. If they are equal, no script is returned.
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 fn path_script_name(path: &Body, pid: u32, ppid: u32, cwd: &[u8], exe: &[u8]) -> Option<NVec> {
     use nix::sys::stat::{major, makedev};
     use std::{
@@ -433,7 +423,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
             state: State::default(),
             next_expire: None,
             emit_fn: Box::new(emit_fn),
-            #[cfg(all(feature = "procfs", target_os = "linux"))]
             exe_hash_cache: None,
             // let max = self.settings.enrich_exe_hash_cache_entries;
             settings: Settings::default(),
@@ -442,7 +431,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
 
     pub fn with_settings(mut self, settings: Settings) -> Self {
         self.settings = settings;
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         if self.settings.enrich_exe_hash_cache_entries > 0 {
             self.exe_hash_cache = Some(ExeHashCache::new(
                 self.settings.enrich_exe_hash_cache_entries,
@@ -586,7 +574,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                 m.push(("ppid".into(), Value::from(proc.ppid as i64)));
             }
         } else {
-            #[cfg(all(feature = "procfs", target_os = "linux"))]
             {
                 if let (true, Some(container_info)) =
                     (self.settings.enrich_container, &proc.container_info)
@@ -719,7 +706,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
         rv.retain(|(k, v)| match (k, v) {
             (k, Value::Str(vr, _q)) => {
                 if k == "saddr" {
-                    #[cfg(target_os = "linux")]
                     if let Ok(sa) = SocketAddr::parse(vr) {
                         // There's no need to enrich saddr entries
                         // that will be dropped, but the raw data
@@ -794,7 +780,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
         script: &Option<NVec>,
         container_info: &mut Option<Body>,
     ) {
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         if let (true, Some(script)) = (self.settings.enrich_script, &script) {
             rv.push((
                 Key::Literal("SCRIPT"),
@@ -803,7 +788,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
         }
 
         if let Some(proc) = process_key.and_then(|k| self.state.processes.get_key(&k)) {
-            #[cfg(all(feature = "procfs", target_os = "linux"))]
             if let (true, Some(c)) = (self.settings.enrich_container, &proc.container_info) {
                 let mut ci = Body::default();
                 ci.push((
@@ -943,7 +927,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
             ));
         }
 
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         'ENV: {
             let Some(env_matcher) = &self.settings.env_matcher else {
                 break 'ENV;
@@ -975,7 +958,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
     /// - collects environment variables for EXECVE events
     /// - registers process in shadow process table for EXECVE events
     fn transform_event(&mut self, ev: &mut Event) {
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         let mut proc = ev
             .process_key
             .as_ref()
@@ -987,7 +969,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
 
         // Handle script enrichment
         // TODO: Look up process per key.
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         let script: Option<NVec> = match (self.settings.enrich_script, &self.settings.label_script)
         {
             (false, None) => None,
@@ -1010,10 +991,7 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                 _ => None,
             },
         };
-        #[cfg(not(all(feature = "procfs", target_os = "linux")))]
-        let script = None;
 
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         if let (Some(ref mut proc), Some(script)) = (&mut proc, &script) {
             if let Some(label_script) = &self.settings.label_script {
                 for label in label_script.matches(script.as_ref()) {
@@ -1215,7 +1193,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                     ..Process::default()
                 };
 
-                #[cfg(all(feature = "procfs", target_os = "linux"))]
                 if self.settings.enrich_container || self.settings.enrich_systemd {
                     let mut container_info: Option<ContainerInfo> = None;
                     let mut systemd_service: Option<Vec<Vec<u8>>> = None;
@@ -1306,13 +1283,11 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
             }
         }
 
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         if let Some(exe) = exe {
             self.enrich_exe_hash(body, pid, exe);
         }
     }
 
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     fn enrich_exe_hash(&mut self, rv: &mut Body, pid: u32, exe: &[u8]) {
         let Some(ref mut cache) = self.exe_hash_cache else {
             return;
@@ -2434,7 +2409,6 @@ type=EOE msg=audit(1740992884.191:7058722):
     }
 
     #[test]
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     fn exe_hash() -> Result<(), Box<dyn Error>> {
         use std::path::PathBuf;
 
@@ -2492,7 +2466,6 @@ type=EOE msg=audit(1615114232.375:99999):
     }
 
     #[test]
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     fn exe_hash_cache() {
         let mut cache = ExeHashCache::new(3);
         assert_eq!(cache.entries.len(), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,12 @@ pub mod json;
 pub mod label_matcher;
 pub mod logger;
 pub mod proc;
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 pub mod procfs;
 pub(crate) mod quote;
 pub mod rotate;
-#[cfg(target_os = "linux")]
 pub mod sockaddr;
-#[cfg(test)]
-mod test;
 pub mod types;
 pub mod userdb;
+
+#[cfg(test)]
+mod test;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-#[cfg(all(feature = "procfs", target_os = "linux", not(test)))]
 use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Display};
@@ -7,7 +6,6 @@ use std::iter::Iterator;
 use std::str::FromStr;
 use std::vec::Vec;
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 use faster_hex::hex_decode;
 
 use serde::{Deserialize, Serialize};
@@ -20,7 +18,6 @@ use crate::label_matcher::LabelMatcher;
 
 use linux_audit_parser::*;
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 use crate::procfs;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -131,13 +128,10 @@ pub struct Process {
     pub comm: Option<Vec<u8>>,
     /// Labels assigned to process
     pub labels: HashSet<Vec<u8>>,
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     pub container_info: Option<ContainerInfo>,
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     pub systemd_service: Option<Vec<Vec<u8>>>,
 }
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 impl From<procfs::ProcPidInfo> for Process {
     fn from(p: procfs::ProcPidInfo) -> Self {
         Self {
@@ -161,7 +155,6 @@ impl From<procfs::ProcPidInfo> for Process {
     }
 }
 
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 fn extract_sha256(buf: &[u8]) -> Option<Vec<u8>> {
     let mut dec = [0u8; 32];
     match buf.len() {
@@ -173,7 +166,6 @@ fn extract_sha256(buf: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// Try to determine container ID from cgroup path
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 pub(crate) fn try_extract_container_id(path: &[u8]) -> Option<Vec<u8>> {
     for fragment in path.split(|&c| c == b'/') {
         let fragment = if fragment.ends_with(&b".scope"[..]) {
@@ -190,7 +182,6 @@ pub(crate) fn try_extract_container_id(path: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// Try to extract "something.service" fragments from cgroup path
-#[cfg(all(feature = "procfs", target_os = "linux"))]
 pub(crate) fn try_extract_systemd_service(path: &[u8]) -> Option<Vec<Vec<u8>>> {
     let svc: Vec<_> = path
         .split(|&c| c == b'/')
@@ -206,7 +197,6 @@ pub(crate) fn try_extract_systemd_service(path: &[u8]) -> Option<Vec<Vec<u8>>> {
 
 impl Process {
     /// Generate a shadow process table entry from /proc/$PID for a given PID
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     pub fn parse_proc(pid: u32) -> Result<Process, ProcError> {
         procfs::parse_proc_pid(pid)
             .map(|p| p.into())
@@ -216,7 +206,6 @@ impl Process {
 
 #[derive(Debug, Error)]
 pub enum ProcError {
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     #[error("{0}")]
     ProcFSError(procfs::ProcFSError),
 }
@@ -245,7 +234,6 @@ impl ProcTable {
             current: BTreeMap::new(),
         };
 
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         {
             for pid in procfs::get_pids().map_err(ProcError::ProcFSError)? {
                 // /proc/<pid> access is racy. Ignore errors here.
@@ -301,7 +289,6 @@ impl ProcTable {
     /// shadow process table, an attempt is made to fetch the
     /// information from another source, i.e. /proc.
     pub fn get_or_retrieve(&mut self, pid: u32) -> Option<&Process> {
-        #[cfg(all(feature = "procfs", target_os = "linux"))]
         if self.get_pid(pid).is_none() {
             self.insert_from_procfs(pid);
         }
@@ -314,7 +301,6 @@ impl ProcTable {
 
     /// Fetch process information from procfs, insert into shadow
     /// process table.
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     pub fn insert_from_procfs(&mut self, pid: u32) -> Option<&Process> {
         if let Ok(p) = Process::parse_proc(pid) {
             let key = p.key;
@@ -330,7 +316,6 @@ impl ProcTable {
     ///
     /// It should be possible to run this every few seconds without
     /// incurring load.
-    #[cfg(all(feature = "procfs", target_os = "linux", not(test)))]
     pub fn expire(&mut self) {
         let mut proc_prune: BTreeSet<ProcessKey> = self.processes.keys().cloned().collect();
         let mut pid_prune: Vec<u32> = vec![];
@@ -377,11 +362,6 @@ impl ProcTable {
             self.current.remove(&pid);
         }
     }
-
-    /// No expire mechanism has been implemented for the case where
-    /// there's no procfs support.
-    #[cfg(not(all(feature = "procfs", target_os = "linux", not(test))))]
-    pub fn expire(&self) {}
 }
 
 #[cfg(test)]
@@ -453,7 +433,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     fn extract_container_id() {
         for (raw, expected) in &[
             (&b""[..], None),
@@ -469,7 +448,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "procfs", target_os = "linux"))]
     fn extract_systemd_service() {
         for (raw, expected) in &[
             (&b""[..], None),

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -204,9 +204,6 @@ pub(crate) fn parse_proc_pid(pid: u32) -> Result<ProcPidInfo, ProcFSError> {
         tv_sec: (starttime / *CLK_TCK) as _,
         tv_nsec: ((starttime % *CLK_TCK) * (1_000_000_000 / *CLK_TCK)) as _,
     });
-    #[cfg(not(target_os = "linux"))]
-    let proc_age = TimeSpec::from(std::time::Duration::ZERO);
-    #[cfg(target_os = "linux")]
     let proc_age = clock_gettime(ClockId::CLOCK_BOOTTIME)
         .map_err(|e| ProcFSError::Errno("clock_gettime(CLOCK_BOOTTIME)", e))?
         - proc_boottime;

--- a/src/rotate.rs
+++ b/src/rotate.rs
@@ -103,7 +103,6 @@ impl FileRotate {
         let mut acl = vec![
             AclEntry::allow_user("", Perm::from_bits_truncate(6), None),
             AclEntry::allow_group("", Perm::from_bits_truncate(4), None),
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             AclEntry::allow_other(
                 if self.other {
                     Perm::READ


### PR DESCRIPTION
While laurel was initially concieved as an Audit log parser, enrichments that require procfs access are becoming more important for its enrichment and process tracking logic.

I no longer see a sensible use-case where Laurel would be used to post-process Audit decoupled from the system that generated them.