### PR TITLE
Track orphaned processes that end up with ppid=1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +495,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "bindgen",
+ "bstr",
  "caps",
  "divan",
  "exacl",
@@ -755,10 +767,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -772,10 +785,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ aho-corasick = "1.1"
 memchr = "2.8.1"
 itertools = "0.14.0"
 caps = "0.5"
+bstr = "1.12.3"
 
 [build-dependencies]
 bindgen = ">= 0.60"

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -574,30 +574,30 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                 m.push(("ppid".into(), Value::from(proc.ppid as i64)));
             }
         } else {
+            if let Some(ProcessKey::Event(id)) = proc.previous_self {
+                m.push(("PREVIOUS_EVENT_ID".into(), format!("{id}").into()));
+            }
+            if let (true, Some(container_info)) =
+                (self.settings.enrich_container, &proc.container_info)
             {
-                if let (true, Some(container_info)) =
-                    (self.settings.enrich_container, &proc.container_info)
-                {
-                    let id = hex_string(&container_info.id);
-                    m.push((
-                        "container".into(),
-                        Value::Map(vec![("id".into(), id.into())]),
-                    ));
-                }
-
-                if let (true, Some(systemd_service)) =
-                    (self.settings.enrich_systemd, &proc.systemd_service)
-                {
-                    m.push((
-                        "systemd_service".into(),
-                        Value::List(
-                            systemd_service
-                                .iter()
-                                .map(|v| Value::from(v.as_slice()))
-                                .collect(),
-                        ),
-                    ));
-                }
+                let id = hex_string(&container_info.id);
+                m.push((
+                    "container".into(),
+                    Value::Map(vec![("id".into(), id.into())]),
+                ));
+            }
+            if let (true, Some(systemd_service)) =
+                (self.settings.enrich_systemd, &proc.systemd_service)
+            {
+                m.push((
+                    "systemd_service".into(),
+                    Value::List(
+                        systemd_service
+                            .iter()
+                            .map(|v| Value::from(v.as_slice()))
+                            .collect(),
+                    ),
+                ));
             }
         }
 
@@ -1152,89 +1152,87 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
             *filter_event = true;
         }
 
-        let (first_per_process, proc) = match (
-            *is_exec,
-            self.state
-                .processes
-                .get_pid(pid)
-                .filter(|p| p.pid == pid && p.ppid == ppid && p.exe.as_deref() == exe),
-        ) {
-            (false, Some(proc)) => (false, proc.clone()),
-            (_, proc) => {
-                let is_first = *is_exec || proc.is_none();
+        // processes from proc table that matches this event
+        let ppid_proc = self.state.processes.get_or_retrieve(ppid).cloned();
+        let ppid_is_init = ppid_proc.as_ref().is_some_and(|p| p.pid == 1 || p.is_init);
+        let pid_proc = self
+            .state
+            .processes
+            .get_pid(pid)
+            .filter(|p| p.ppid == ppid || ppid_is_init);
 
-                if let Some(pre_exec_proc) = self
-                    .state
-                    .processes
-                    .get_pid(pid)
-                    .and_then(|p| (ppid == p.ppid).then_some(p))
-                {
-                    self.propagate_labels(pre_exec_proc, &mut labels);
-                }
+        let proc;
+        let first_per_process;
 
-                let parent_proc = self.state.processes.get_or_retrieve(ppid).cloned();
-                let parent = parent_proc.as_ref().map(|p| p.key);
+        // handle new process
+        if *is_exec || pid_proc.filter(|p| p.exe.as_deref() == exe).is_none() {
+            let previous_self_proc = pid_proc;
 
-                if let Some(ref p) = parent_proc {
+            if let Some(ref p) = ppid_proc {
+                if !p.is_init {
                     self.propagate_labels(p, &mut labels)
+                }
+            }
+            if *is_exec {
+                if let Some(p) = previous_self_proc {
+                    self.propagate_labels(p, &mut labels);
                 }
                 if let Some(exe) = exe {
                     self.label_exe(exe, &mut labels)
                 }
-
-                let mut new_proc = Process {
-                    key: ProcessKey::Event(id),
-                    parent,
-                    pid,
-                    ppid,
-                    labels,
-                    exe: exe.map(Vec::from),
-                    comm: comm.map(Vec::from),
-                    ..Process::default()
-                };
-
-                if self.settings.enrich_container || self.settings.enrich_systemd {
-                    let mut container_info: Option<ContainerInfo> = None;
-                    let mut systemd_service: Option<Vec<Vec<u8>>> = None;
-                    let cgroup = procfs::parse_proc_pid_cgroup(pid).ok().flatten();
-                    if self.settings.enrich_container {
-                        container_info = match cgroup {
-                            Some(ref path) => {
-                                proc::try_extract_container_id(path).map(|id| ContainerInfo { id })
-                            }
-                            _ => parent_proc.as_ref().and_then(|p| p.container_info.clone()),
-                        };
-                    }
-                    if self.settings.enrich_systemd {
-                        systemd_service = match cgroup {
-                            Some(ref path) => proc::try_extract_systemd_service(path),
-                            _ => parent_proc.as_ref().and_then(|p| p.systemd_service.clone()),
-                        };
-                    }
-                    new_proc.container_info = container_info;
-                    new_proc.systemd_service = systemd_service;
-                }
-
-                self.state.processes.insert(new_proc.clone());
-                (is_first, new_proc)
             }
-        };
 
-        if proc
-            .labels
-            .intersection(&self.settings.filter_labels)
-            .next()
-            .is_some()
-        {
-            *filter_event = true;
-        }
+            let mut container_info = None;
+            let mut systemd_service = None;
 
-        // TODO: This logic needs to be split.
-        if first_per_process && !self.settings.filter_first_per_process {
-            *filter_event = false;
+            if self.settings.enrich_container || self.settings.enrich_systemd {
+                let cgroup = procfs::parse_proc_pid_cgroup(pid).ok().flatten();
+                if self.settings.enrich_container {
+                    container_info = match cgroup {
+                        Some(ref path) => {
+                            proc::try_extract_container_id(path).map(|id| ContainerInfo { id })
+                        }
+                        _ => ppid_proc.as_ref().and_then(|p| p.container_info.clone()),
+                    };
+                }
+                if self.settings.enrich_systemd {
+                    systemd_service = match cgroup {
+                        Some(ref path) => proc::try_extract_systemd_service(path),
+                        _ => ppid_proc.as_ref().and_then(|p| p.systemd_service.clone()),
+                    };
+                }
+            }
+
+            let is_init = procfs::is_pid1(pid);
+
+            first_per_process = true;
+            proc = Process {
+                key: ProcessKey::Event(id),
+                parent: ppid_proc.as_ref().map(|p| p.key),
+                previous_self: previous_self_proc.map(|p| p.key),
+                pid,
+                is_init,
+                ppid,
+                labels,
+                exe: exe.map(Vec::from),
+                comm: comm.map(Vec::from),
+                container_info,
+                systemd_service,
+            };
+            self.state.processes.insert(proc.clone());
+        } else {
+            first_per_process = false;
+            proc = pid_proc.cloned().unwrap();
         }
 
         *process_key = Some(proc.key);
+
+        *filter_event |= proc
+            .labels
+            .intersection(&self.settings.filter_labels)
+            .next()
+            .is_some();
+        *filter_event &= !(first_per_process && !self.settings.filter_first_per_process);
 
         // No point in adding translations / enrichments to record if
         // we are going to filter anyway.
@@ -2219,10 +2217,10 @@ mod test {
         let events = events.borrow();
 
         for id in [
-            "1778355636.725:2322552",
-            "1778355636.728:2322553",
-            "1778355636.752:2322555",
-            "1778355636.754:2322557",
+            "1778355636.725:2322552", // dpkg -l
+            "1778355636.728:2322553", // dpkg-query --list --
+            "1778355636.752:2322555", // sh -c -- pager
+            "1778355636.754:2322557", // pager
         ] {
             let event = find_event(&events, id).unwrap_or_else(|| panic!("did not find {id}"));
             let j = event_to_json(&event);
@@ -2232,6 +2230,37 @@ mod test {
                 "{id} should inherit label"
             )
         }
+    }
+
+    #[test]
+    fn fork_sleep_exec() {
+        let s = Settings {
+            label_exe: LabelMatcher::new(&[("/uncaring-parent$", "uncaring-parent")]).ok(),
+            proc_propagate_labels: [b"uncaring-parent".to_vec()].into(),
+            ..Settings::default()
+        };
+        let events: Rc<RefCell<Vec<Event>>> = Rc::new(RefCell::new(vec![]));
+        let mut c = Coalesce::new(mk_emit_vec(&events));
+        c.settings = s;
+
+        process_record(&mut c, include_bytes!("testdata/fork-sleep-exec.txt")).unwrap();
+
+        drop(c);
+
+        let events = events.borrow();
+
+        let id = "1783860945.368:6104008";
+        let event = find_event(&events, id).unwrap_or_else(|| panic!("did not find {id}"));
+        let j = event_to_json(&event);
+        println!("{j}");
+        assert!(
+            j.contains(r#""PREVIOUS_EVENT_ID":"#),
+            "{id} should have a previous event id"
+        );
+        assert!(
+            j.contains(r#""LABELS":["uncaring-parent"]}"#),
+            "{id} should have 'uncaring-parente' label applied"
+        );
     }
 
     #[test]

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -114,8 +114,10 @@ impl PartialOrd for ProcessKey {
 pub struct Process {
     /// "primary key", unique per host
     pub key: ProcessKey,
-    /// parent's key, if a parent has been recorded.
+    /// parent's key, if known, at of time of process creation.
     pub parent: Option<ProcessKey>,
+    /// Previous process instance if execve FIXME
+    pub previous_self: Option<ProcessKey>,
     /// process ID
     pub pid: u32,
     /// true if the process has the "init" (pid=1) role in its namespace

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -118,6 +118,8 @@ pub struct Process {
     pub parent: Option<ProcessKey>,
     /// process ID
     pub pid: u32,
+    /// true if the process has the "init" (pid=1) role in its namespace
+    pub is_init: bool,
     /// parent's porocess ID
     pub ppid: u32,
     /// path to binary
@@ -139,8 +141,8 @@ impl From<procfs::ProcPidInfo> for Process {
                 time: p.starttime,
                 pid: p.pid,
             },
-            parent: None,
             pid: p.pid,
+            is_init: p.is_pid1,
             ppid: p.ppid,
             labels: HashSet::new(),
             exe: p.exe,
@@ -151,6 +153,7 @@ impl From<procfs::ProcPidInfo> for Process {
                 .and_then(try_extract_container_id)
                 .map(|id| ContainerInfo { id }),
             systemd_service: p.cgroup.as_deref().and_then(try_extract_systemd_service),
+            ..Default::default()
         }
     }
 }

--- a/src/procfs.rs
+++ b/src/procfs.rs
@@ -21,7 +21,7 @@ lazy_static! {
 
 #[derive(Debug, Error)]
 pub enum ProcFSError {
-    #[error("can't read /proc/{pid}/(obj): {err}")]
+    #[error("can't read /proc/{pid}/{obj}: {err}")]
     PidFile {
         pid: u32,
         obj: &'static str,
@@ -180,12 +180,13 @@ pub(crate) struct ProcPidInfo {
     pub exe: Option<Vec<u8>>,
     /// from /proc/$PID/cgroup
     pub cgroup: Option<Vec<u8>>,
+    /// derived from NSpid in /proc/$PID/status
+    pub is_pid1: bool,
 }
 
 /// Parses information from /proc entry corresponding to process pid
 pub(crate) fn parse_proc_pid(pid: u32) -> Result<ProcPidInfo, ProcFSError> {
     let buf = slurp_pid_obj(pid, "stat")?;
-
     let ProcStat {
         pid,
         ppid,
@@ -194,6 +195,7 @@ pub(crate) fn parse_proc_pid(pid: u32) -> Result<ProcPidInfo, ProcFSError> {
         ..
     } = parse_proc_pid_stat(&buf)?;
 
+    let is_pid1 = is_pid1(pid);
     let exe = read_link(format!("/proc/{pid}/exe"))
         .map(|p| Vec::from(p.as_os_str().as_bytes()))
         .ok();
@@ -223,7 +225,18 @@ pub(crate) fn parse_proc_pid(pid: u32) -> Result<ProcPidInfo, ProcFSError> {
         comm: comm.to_vec(),
         exe,
         cgroup,
+        is_pid1,
     })
+}
+
+pub fn is_pid1(pid: u32) -> bool {
+    use bstr::ByteSlice;
+    let Ok(buf) = slurp_pid_obj(pid, "status") else {
+        return false;
+    };
+    ByteSlice::lines(buf.as_slice())
+        .filter_map(|line| line.strip_prefix(b"NSpid:"))
+        .any(|value| value.trim_end().ends_with(b"\t1"))
 }
 
 /// Parses path (third field) /proc/pid/cgroup
@@ -246,7 +259,7 @@ mod tests {
     #[test]
     fn parse_self() {
         let pid = std::process::id();
-        let proc = parse_proc_pid(pid).unwrap_or_else(|_| panic!("parse entry for {pid}"));
+        let proc = parse_proc_pid(pid).unwrap_or_else(|e| panic!("parse entry for {pid}: {e}"));
         println!("{proc:?}");
     }
 

--- a/src/testdata/fork-sleep-exec.txt
+++ b/src/testdata/fork-sleep-exec.txt
@@ -1,0 +1,30 @@
+# orphan = simple demo program
+#
+# usleep is being used to stay below EXPIRE_PERIOD.
+#
+# #include <unistd.h>
+# int main() {
+#   if (fork()) { usleep(100); return 0; }
+#   if (!fork()) return 0;
+#   usleep(200);
+#   execve("/bin/true", NULL, NULL);
+# }
+
+# run demo program
+type=PATH msg=audit(1783860945.368:6104005): item=2 name="/lib/ld-linux-aarch64.so.1" inode=79199 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=PATH msg=audit(1783860945.368:6104005): item=1 name="/home/user/bin/uncaring-parent" inode=2228401 dev=fd:01 mode=0100775 ouid=1000 ogid=1000 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=PATH msg=audit(1783860945.368:6104005): item=0 name="/home/user/bin/uncaring-parent" inode=2228401 dev=fd:01 mode=0100775 ouid=1000 ogid=1000 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=CWD msg=audit(1783860945.368:6104005): cwd="/home/user"
+type=EXECVE msg=audit(1783860945.368:6104005): argc=1 a0="/home/user/bin/uncaring-parent"
+type=SYSCALL msg=audit(1783860945.368:6104005): arch=c00000b7 syscall=221 success=yes exit=0 a0=555589d0c560 a1=555589fb9ad0 a2=555589a94500 a3=7fffbb317b60 items=3 ppid=3822680 pid=1578539 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts9 ses=2 comm="uncaring-parent" exe="/home/user/bin/uncaring-parent" subj=unconfined key=(null)
+
+# child forks so we have an observable event.
+type=SYSCALL msg=audit(1783860945.368:6104007): arch=c00000b7 syscall=220 success=yes exit=1578541 a0=1200011 a1=0 a2=0 a3=0 items=0 ppid=1578539 pid=1578540 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts9 ses=2 comm="uncaring-parent" exe="/home/user/bin/uncaring-parent" subj=unconfined key="fork"
+
+# child execs; parent has exited already, hence ppid=1
+type=PATH msg=audit(1783860945.368:6104008): item=2 name="/lib/ld-linux-aarch64.so.1" inode=79199 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=PATH msg=audit(1783860945.368:6104008): item=1 name="/bin/true" inode=24801 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=PATH msg=audit(1783860945.368:6104008): item=0 name="/bin/true" inode=24801 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+type=CWD msg=audit(1783860945.368:6104008): cwd="/home/user"
+type=EXECVE msg=audit(1783860945.368:6104008): argc=1 a0=""
+type=SYSCALL msg=audit(1783860945.368:6104008): arch=c00000b7 syscall=221 success=yes exit=0 a0=55555b7208a8 a1=0 a2=0 a3=0 items=3 ppid=1 pid=1578540 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts9 ses=2 comm="true" exe="/usr/bin/true" subj=unconfined key=(null)


### PR DESCRIPTION
If a child process calls execve(2) after its parent has terminated, a
SYSCALL message with ppid=1 is generated along with the EXECVE
message.

This reflects what has changed in the kernel's process table. Howver,
Laurel's existing logic for process tracking and label propagation got
confused by orphaned children being adopted.

The effect itself can be demonstrated using the following short C
program:

    #include <unistd.h>
    int main() {
      if (fork()) { usleep(100); return 0; }
      if (!fork()) return 0;
      usleep(200);
      execve("/bin/true", 0, 0);
    }

When checking whether a SYSCALL message belongs to a known process, it
is now considered whether the parent has been set to pid1 (globally or
for a pid namespace). Confusion by regular PID reuse is going to be
unlikely because stale process entries are purged from the active
process list of Laurel's shadow process table every
second (`coalesce::EXPIRE_PERIOD`).

Since it would be undesirable to add a wrong/misleading
SYSCALL.PPID.EVENT_ID enrichmend that points to something other than
pid 1, a new field SYSCALL.PID.PREVIOUS_EVENT_ID is added instead.
With this extra identifier, more reliable tracking of program
executions from the logs should be possible.

Support for propagating labels across plain execve calls (without
fork) had already been implemented, cf.
6dfcd86022b6951a59c08d3054a98900abc1dbae.
