### PR TITLE
Replace PREVIOUS_EVENT_ID, with SPAWNED_BY enrichment record

### DIFF
--- a/etc/laurel/config.toml
+++ b/etc/laurel/config.toml
@@ -103,6 +103,11 @@ drop-raw = false
 
 # Add context (event-id, comm, exe, ppid) for *pid entries
 pid = true
+# Log comm, exe, ppid as part of SYSCALL.PPID. Deprecated.
+ppid-verbose = false
+# Add SYSCALL.SPAWNED_BY.* enrichment about the process responsible
+# for spawning the current process.
+spawned-by = true
 
 # List of environment variables to log for every EXECVE event.
 # Prefix matches are used for strings ending with an asterisk ("*")
@@ -195,7 +200,7 @@ propagate-labels = [ "software_mgmt", "amazon-ssm-agent" ]
 # filter-keys = ["filter-this"]
 
 # In addition to key based filtering it is also possible to configure label based 
-# filtering. This alows the possibility to filter based on parent processes.
+# filtering. This allows the possibility to filter based on parent processes.
 
 # filter-labels = ["software_mgmt"]
 

--- a/man/laurel-about.7.md
+++ b/man/laurel-about.7.md
@@ -93,7 +93,11 @@ Mechanisms by which labels can be assigned include:
 - regular expression applied to part of the command line (`EXECVE.ARGV` field)
 - regular expression applied to the script path (`SYSCALL.SCRIPT` field, enriched)
 
-The process tracking information can be used to enrich fields containing process ids, including `SYSCALL.{pid, ppid}` and `OBJ_PID.opid` associated with `ptrace` attach or `kill` syscalls.
+The process tracking information can be used to enrich fields containing process ids, including `SYSCALL.{pid, ppid}` and `OBJ_PID.opid` associated with `ptrace` attach or `kill` syscalls. Enrichment is done using capitalized `*PID` fields that contain at least an `EVENT_ID` referring to the first audit event observed for that process or `START_TIME` if no such audit event was observed. Extra `comm` and `exe` are added where useful.
+
+To reconstruct a process-tree-like structure from `Laurel`'s audit logs, the `SYSCALL.SPAWNED_BY.*` enrichment is most useful.
+
+If a process has been started using a combination of `fork` and `exec` syscalls, `SYSCALL.SPAWNED_BY` contains information from the parent process referred to by `SYSCALL.ppid` when the `exec` call was observed. If the process was created from a previously observed process using a plain `exec` syscall, this record contains information from that previous process with the same `pid`. Fields include `EVENT_ID`/`START_TIME`, `comm`, `exe`, and `pid`.
 
 ### Volume reduction: Filtering out events
 

--- a/man/laurel.8.md
+++ b/man/laurel.8.md
@@ -169,6 +169,15 @@ Options that can be configured here actually add information to events
 - `container_info`: Add container information as top-level
   `CONTAINER_INFO` key. Deprecated; default: false
 - `pid`: Add context information for process IDs. Default: true
+- `ppid-verbose`: As part of the `SYSCALL.PPID.*` enrichment, the first
+  event ID referring to the parent process or its start time is
+  logged. If this option is set, the `comm`, `exe`, and `ppid` fields
+  are added. Deprecated, see `spawned-by`. Default: false
+- `spawned-by`: Add `SYSCALL.SPAWNED_BY.*` enrichments that contains
+  information about the process responsible for spawning the current
+  process. This is a replacement for the `SYSCALL.PPID` enrichment.
+  For a more detailed discussion, see section "Adding Context: Process
+  Relationships, Labels" in `laurel-about(7)`. Default: true
 - `script`: If an `exec` syscall spawns a script (as opposed to a
   binary), add a `SCRIPT` entry to the `SYSCALL` record. A script is
   assumed if the first `PATH` entry does not correspond to file

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -67,6 +67,7 @@ pub struct Settings {
     pub enrich_container_info: bool,
     pub enrich_systemd: bool,
     pub enrich_pid: bool,
+    pub enrich_spawned_by: bool,
     pub enrich_script: bool,
     pub enrich_uid_groups: bool,
     pub enrich_exe_hash: bool,
@@ -109,6 +110,7 @@ impl Default for Settings {
             enrich_container_info: false,
             enrich_systemd: false,
             enrich_pid: true,
+            enrich_spawned_by: true,
             enrich_script: true,
             enrich_uid_groups: true,
             enrich_exe_hash: false,
@@ -571,9 +573,6 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                 m.push(("ppid".into(), Value::from(proc.ppid as i64)));
             }
         } else {
-            if let Some(ProcessKey::Event(id)) = proc.previous_self {
-                m.push(("PREVIOUS_EVENT_ID".into(), format!("{id}").into()));
-            }
             if let (true, Some(container_info)) =
                 (self.settings.enrich_container, &proc.container_info)
             {
@@ -785,6 +784,33 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
         }
 
         if let Some(proc) = process_key.and_then(|k| self.state.processes.get_key(&k)) {
+            if let (true, Some(spawner_key)) = (
+                self.settings.enrich_spawned_by,
+                proc.previous_self.or(proc.parent),
+            ) {
+                let mut m = Vec::new();
+                match spawner_key {
+                    ProcessKey::Event(id) => {
+                        m.push(("EVENT_ID".into(), format!("{id}").into()));
+                    }
+                    ProcessKey::Observed { time, pid: _ } => {
+                        let (sec, msec) = (time / 1000, time % 1000);
+                        m.push(("START_TIME".into(), format!("{sec}.{msec:03}").into()));
+                    }
+                }
+                if let Some(spawner_proc) = self.state.processes.get_key(&spawner_key) {
+                    m.push(("pid".into(), Value::from(spawner_proc.pid as i64)));
+                    if let Some(comm) = &spawner_proc.comm {
+                        m.push(("comm".into(), Value::from(comm.as_slice())));
+                    }
+                    if let Some(exe) = &spawner_proc.exe {
+                        m.push(("exe".into(), Value::from(exe.as_slice())));
+                    }
+                    m.push(("pid".into(), Value::from(spawner_proc.pid as i64)));
+                }
+                rv.push((Key::Literal("SPAWNED_BY"), Value::Map(m)));
+            }
+
             if let (true, Some(c)) = (self.settings.enrich_container, &proc.container_info) {
                 let mut ci = Body::default();
                 ci.push((
@@ -2250,7 +2276,7 @@ mod test {
         let j = event_to_json(&event);
         println!("{j}");
         assert!(
-            j.contains(r#""PREVIOUS_EVENT_ID":"#),
+            j.contains(r#""SPAWNED_BY":{"EVENT_ID":"#),
             "{id} should have a previous event id"
         );
         assert!(

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -67,6 +67,7 @@ pub struct Settings {
     pub enrich_container_info: bool,
     pub enrich_systemd: bool,
     pub enrich_pid: bool,
+    pub enrich_ppid_verbose: bool,
     pub enrich_spawned_by: bool,
     pub enrich_script: bool,
     pub enrich_uid_groups: bool,
@@ -110,6 +111,7 @@ impl Default for Settings {
             enrich_container_info: false,
             enrich_systemd: false,
             enrich_pid: true,
+            enrich_ppid_verbose: false,
             enrich_spawned_by: true,
             enrich_script: true,
             enrich_uid_groups: true,
@@ -562,17 +564,7 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                 m.push(("START_TIME".into(), format!("{sec}.{msec:03}").into()));
             }
         }
-        if name != b"pid" {
-            if let Some(comm) = &proc.comm {
-                m.push(("comm".into(), Value::from(comm.as_slice())));
-            }
-            if let Some(exe) = &proc.exe {
-                m.push(("exe".into(), Value::from(exe.as_slice())));
-            }
-            if proc.ppid != 0 {
-                m.push(("ppid".into(), Value::from(proc.ppid as i64)));
-            }
-        } else {
+        if name == b"pid" {
             if let (true, Some(container_info)) =
                 (self.settings.enrich_container, &proc.container_info)
             {
@@ -594,6 +586,16 @@ impl<'a, 'ev> Coalesce<'a, 'ev> {
                             .collect(),
                     ),
                 ));
+            }
+        } else if name != b"ppid" || self.settings.enrich_ppid_verbose {
+            if let Some(comm) = &proc.comm {
+                m.push(("comm".into(), Value::from(comm.as_slice())));
+            }
+            if let Some(exe) = &proc.exe {
+                m.push(("exe".into(), Value::from(exe.as_slice())));
+            }
+            if proc.ppid != 0 {
+                m.push(("ppid".into(), Value::from(proc.ppid as i64)));
             }
         }
 
@@ -2290,10 +2292,12 @@ mod test {
         let s1 = Settings {
             proc_label_keys: [b"test-script".to_vec()].into(),
             proc_propagate_labels: [b"test-script".to_vec()].into(),
+            enrich_ppid_verbose: true,
             ..Settings::default()
         };
         let s2 = Settings {
             filter_keys: [b"fork".to_vec()].into(),
+            enrich_ppid_verbose: true,
             ..s1.clone()
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,8 @@ pub struct Enrich {
     pub systemd: bool,
     #[serde(default = "true_value")]
     pub pid: bool,
+    #[serde(default = "true_value", rename = "spawned-by")]
+    pub spawned_by: bool,
     #[serde(default = "true_value")]
     pub script: bool,
     #[serde(default = "true_value", rename = "uid-groups")]
@@ -177,6 +179,7 @@ impl Default for Enrich {
             container_info: false,
             systemd: true,
             pid: true,
+            spawned_by: true,
             script: true,
             uid_groups: true,
             prefix: None,
@@ -457,6 +460,7 @@ impl Config {
             enrich_container_info: self.enrich.container_info,
             enrich_systemd: self.enrich.systemd,
             enrich_pid: self.enrich.pid,
+            enrich_spawned_by: self.enrich.spawned_by,
             enrich_script: self.enrich.script,
             enrich_uid_groups: self.enrich.uid_groups,
             enrich_exe_hash: self.enrich.exe_hash,

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,8 @@ pub struct Enrich {
     pub pid: bool,
     #[serde(default = "true_value", rename = "spawned-by")]
     pub spawned_by: bool,
+    #[serde(default, rename = "ppid-verbose")]
+    pub ppid_verbose: bool,
     #[serde(default = "true_value")]
     pub script: bool,
     #[serde(default = "true_value", rename = "uid-groups")]
@@ -179,6 +181,7 @@ impl Default for Enrich {
             container_info: false,
             systemd: true,
             pid: true,
+            ppid_verbose: false,
             spawned_by: true,
             script: true,
             uid_groups: true,
@@ -460,6 +463,7 @@ impl Config {
             enrich_container_info: self.enrich.container_info,
             enrich_systemd: self.enrich.systemd,
             enrich_pid: self.enrich.pid,
+            enrich_ppid_verbose: self.enrich.ppid_verbose,
             enrich_spawned_by: self.enrich.spawned_by,
             enrich_script: self.enrich.script,
             enrich_uid_groups: self.enrich.uid_groups,

--- a/src/test.rs
+++ b/src/test.rs
@@ -63,6 +63,7 @@ fn golden() -> Result<(), Box<dyn Error>> {
         let mut c = Coalesce::new(emit_fn);
         c.settings.enrich_uid_groups = false;
         c.settings.enrich_pid = false;
+        c.settings.enrich_spawned_by = false;
         c.settings.enrich_script = false;
 
         let txtfile = prefix.join(file);


### PR DESCRIPTION
SYSCALL.SPAWNED_BY contains information about the process that is (most
likely) responsible for spawning the current process (SYSCALL.pid).

If the current process was created using fork/exec in short
succession, SPAWNED_BY will describe the parent
process (SYSCALL.ppid). If the child process has made noteworthy calls
before calling execve, SPAWNED_BY will refer to the pre-exec instance
of the process (SYSCALL.pid).

This conceptionally replaces SYSCALL.PPID enrichment, but that can still be enabled.